### PR TITLE
Improve support for multiple cars

### DIFF
--- a/custom_components/polestar_api/__init__.py
+++ b/custom_components/polestar_api/__init__.py
@@ -44,7 +44,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
             await polestar.init(car_index)
             polestar.set_config_unit(hass.config.units)
             entities.append(polestar)
-            _LOGGER.debug("Added entity for %s", polestar.vin)
+            _LOGGER.debug("Added entity for VIN %s", polestar.vin)
 
         hass.data[DOMAIN][config_entry.entry_id] = entities
 

--- a/custom_components/polestar_api/__init__.py
+++ b/custom_components/polestar_api/__init__.py
@@ -35,7 +35,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     hass.data.setdefault(DOMAIN, {})
 
     try:
-        await coordinator.init()
+        await coordinator.async_init()
 
         entities: list[PolestarCar] = []
         for car in coordinator.get_cars():

--- a/custom_components/polestar_api/__init__.py
+++ b/custom_components/polestar_api/__init__.py
@@ -8,7 +8,7 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 
-from .const import DOMAIN
+from .const import CONF_VIN, DOMAIN
 from .polestar import PolestarCar, PolestarCoordinator
 from .pypolestar.exception import PolestarApiException, PolestarAuthException
 
@@ -30,7 +30,12 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     conf = config_entry.data
 
     _LOGGER.debug("async_setup_entry: %s", config_entry)
-    coordinator = PolestarCoordinator(hass, conf[CONF_USERNAME], conf[CONF_PASSWORD])
+    coordinator = PolestarCoordinator(
+        hass=hass,
+        username=conf[CONF_USERNAME],
+        password=conf[CONF_PASSWORD],
+        vin=conf.get(CONF_VIN),
+    )
 
     hass.data.setdefault(DOMAIN, {})
 

--- a/custom_components/polestar_api/config_flow.py
+++ b/custom_components/polestar_api/config_flow.py
@@ -36,7 +36,7 @@ class FlowHandler(config_entries.ConfigFlow):
 
         try:
             device = PolestarCoordinator(self.hass, username, password)
-            await device.init()
+            await device.async_init()
 
             # check if we have a token, otherwise throw exception
             if device.polestar_api.auth.access_token is None:

--- a/custom_components/polestar_api/config_flow.py
+++ b/custom_components/polestar_api/config_flow.py
@@ -8,7 +8,7 @@ from aiohttp import ClientError
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
-from .const import DOMAIN
+from .const import CONF_VIN, DOMAIN
 from .polestar import PolestarCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -21,22 +21,28 @@ class FlowHandler(config_entries.ConfigFlow):
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
-    async def _create_entry(self, username: str, password: str) -> None:
+    async def _create_entry(self, username: str, password: str, vin: str) -> None:
         """Register new entry."""
         return self.async_create_entry(
             title="Polestar EV",
-            data={
-                CONF_USERNAME: username,
-                CONF_PASSWORD: password,
-            },
+            data={CONF_USERNAME: username, CONF_PASSWORD: password, CONF_VIN: vin},
         )
 
-    async def _create_device(self, username: str, password: str) -> None:
+    async def _create_device(self, username: str, password: str, vin: str) -> None:
         """Create device."""
 
         try:
-            device = PolestarCoordinator(self.hass, username, password)
+            device = PolestarCoordinator(
+                hass=self.hass,
+                username=username,
+                password=password,
+                vin=vin,
+            )
             await device.async_init()
+
+            # check that we found cars
+            if not len(device.get_cars()):
+                return self.async_abort(reason="no_cars")
 
             # check if we have a token, otherwise throw exception
             if device.polestar_api.auth.access_token is None:
@@ -54,7 +60,7 @@ class FlowHandler(config_entries.ConfigFlow):
             _LOGGER.exception("Unexpected error creating device")
             return self.async_abort(reason="api_failed")
 
-        return await self._create_entry(username, password)
+        return await self._create_entry(username, password, vin)
 
     async def async_step_user(self, user_input: dict = None) -> None:
         """User initiated config flow."""
@@ -62,15 +68,23 @@ class FlowHandler(config_entries.ConfigFlow):
             return self.async_show_form(
                 step_id="user",
                 data_schema=vol.Schema(
-                    {vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str}
+                    {
+                        vol.Required(CONF_USERNAME): str,
+                        vol.Required(CONF_PASSWORD): str,
+                        vol.Optional(CONF_VIN): str,
+                    }
                 ),
             )
         return await self._create_device(
-            user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
+            username=user_input[CONF_USERNAME],
+            password=user_input[CONF_PASSWORD],
+            vin=user_input[CONF_VIN],
         )
 
     async def async_step_import(self, user_input: dict) -> None:
         """Import a config entry."""
         return await self._create_device(
-            user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
+            username=user_input[CONF_USERNAME],
+            password=user_input[CONF_PASSWORD],
+            vin=user_input.get(CONF_VIN, ""),
         )

--- a/custom_components/polestar_api/config_flow.py
+++ b/custom_components/polestar_api/config_flow.py
@@ -9,7 +9,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
 from .const import DOMAIN
-from .polestar import Polestar
+from .polestar import PolestarCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,11 +35,11 @@ class FlowHandler(config_entries.ConfigFlow):
         """Create device."""
 
         try:
-            device = Polestar(self.hass, username, password)
+            device = PolestarCoordinator(self.hass, username, password)
             await device.init()
 
             # check if we have a token, otherwise throw exception
-            if device.polestarApi.auth.access_token is None:
+            if device.polestar_api.auth.access_token is None:
                 _LOGGER.exception(
                     "No token, Could be wrong credentials (invalid email or password))"
                 )

--- a/custom_components/polestar_api/const.py
+++ b/custom_components/polestar_api/const.py
@@ -4,3 +4,5 @@ DOMAIN = "polestar_api"
 TIMEOUT = 90
 
 CACHE_TIME = 30
+
+CONF_VIN = Final = "vin"

--- a/custom_components/polestar_api/entity.py
+++ b/custom_components/polestar_api/entity.py
@@ -4,7 +4,7 @@ import logging
 
 from homeassistant.helpers.entity import Entity
 
-from .polestar import Polestar
+from .polestar import PolestarCar
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -12,7 +12,7 @@ _LOGGER = logging.getLogger(__name__)
 class PolestarEntity(Entity):
     """Base class for Polestar entities."""
 
-    def __init__(self, device: Polestar) -> None:
+    def __init__(self, device: PolestarCar) -> None:
         """Initialize the Polestar entity."""
         self.device = device
         self._attr_device_info = device.get_device_info()

--- a/custom_components/polestar_api/image.py
+++ b/custom_components/polestar_api/image.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import DOMAIN as POLESTAR_API_DOMAIN
 from .entity import PolestarEntity
-from .polestar import Polestar
+from .polestar import PolestarCar
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -49,10 +49,8 @@ async def async_setup_entry(
 ) -> None:
     """Set up Polestar image entities based on a config entry."""
 
-    devices: list[Polestar] = hass.data[POLESTAR_API_DOMAIN][entry.entry_id]
+    devices: list[PolestarCar] = hass.data[POLESTAR_API_DOMAIN][entry.entry_id]
     for device in devices:
-        # put data in cache
-        await device.async_update()
         images = [
             PolestarImage(device, description, hass)
             for description in POLESTAR_IMAGE_TYPES
@@ -68,7 +66,7 @@ class PolestarImage(PolestarEntity, ImageEntity):
 
     def __init__(
         self,
-        device: Polestar,
+        device: PolestarCar,
         description: PolestarImageDescription,
         hass: HomeAssistant,
     ) -> None:

--- a/custom_components/polestar_api/polestar.py
+++ b/custom_components/polestar_api/polestar.py
@@ -126,6 +126,11 @@ class PolestarCoordinator:
         self, hass: HomeAssistant, username: str, password: str, vin: str | None
     ) -> None:
         """Initialize the Polestar API."""
+        if vin:
+            _LOGGER.debug("Configure Polestar API client for car with VIN %s", vin)
+        else:
+            _LOGGER.debug("Configure Polestar API client for all cars")
+
         self.polestar_api = PolestarApi(
             username=username,
             password=password,

--- a/custom_components/polestar_api/polestar.py
+++ b/custom_components/polestar_api/polestar.py
@@ -7,7 +7,6 @@ import httpx
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.httpx_client import get_async_client
-from homeassistant.util.unit_system import METRIC_SYSTEM, UnitSystem
 from urllib3 import disable_warnings
 
 from .const import DOMAIN as POLESTAR_API_DOMAIN
@@ -23,33 +22,17 @@ class UnknownVIN(ValueError):
     pass
 
 
-class Polestar:
+class PolestarCar:
     """Polestar EV integration."""
 
-    def __init__(self, hass: HomeAssistant, username: str, password: str) -> None:
-        """Initialize the Polestar API."""
-        self.polestarApi = PolestarApi(username, password, get_async_client(hass))
-        self.name = "Polestar UNKNOWN"
-        self.car = None
-        self.vin = None
-        self.model = None
-        self.unit_system = METRIC_SYSTEM
-        disable_warnings()
-
-    async def init(self, car: int = 0):
-        """Initialize the Polestar API."""
-        await self.polestarApi.init()
-        self.car = car
-        self.polestarApi.set_car_data(car)
-
-        if vin := self.get_value("getConsumerCarsV2", "vin", True):
-            # fill the vin and id in the constructor
-            self.vin = vin
-            self.name = "Polestar " + self.get_unique_id()
-        else:
-            _LOGGER.warning("No VIN for car index %d", self.car)
-
-        self.model = self.get_value("getConsumerCarsV2", "content/model/name")
+    def __init__(self, api: PolestarApi, vin: str) -> None:
+        """Initialize the Polestar Car."""
+        self.polestar_api = api
+        self.vin = vin
+        self.name = "Polestar " + self.get_unique_id()
+        self.model = (
+            self.get_value("getConsumerCarsV2", "content/model/name") or "Unknown model"
+        )
 
     def get_unique_id(self) -> str:
         """Last 4 character of the VIN"""
@@ -59,8 +42,6 @@ class Polestar:
 
     def get_device_info(self) -> DeviceInfo:
         """Return DeviceInfo for current device"""
-        if self.vin is None:
-            raise UnknownVIN
         return DeviceInfo(
             identifiers={(POLESTAR_API_DOMAIN, self.vin)},
             manufacturer="Polestar",
@@ -69,81 +50,92 @@ class Polestar:
             serial_number=self.vin,
         )
 
-    def get_number_of_cars(self):
-        """Get the number of cars."""
-        return self.polestarApi.get_number_of_cars()
-
-    def get_token_expiry(self):
-        """Get the token expiry time."""
-        return self.polestarApi.auth.token_expiry
-
     def get_latest_data(self, query: str, field_name: str):
         """Get the latest data from the Polestar API."""
-        return self.polestarApi.get_latest_data(query, field_name)
-
-    def get_latest_call_code_v1(self):
-        """Get the latest call code mystar API."""
-        return self.polestarApi.latest_call_code
-
-    def get_latest_call_code_v2(self):
-        """Get the latest call code mystar-v2 API."""
-        return self.polestarApi.latest_call_code_2
-
-    def get_latest_call_code_auth(self):
-        """Get the latest call code mystar API."""
-        return self.polestarApi.auth.latest_call_code
-
-    def get_latest_call_code(self):
-        """Get the latest call code."""
-        # if AUTH code last code is not 200 then we return that error code,
-        # otherwise just give the call_code in API from v1 and then v2
-        if self.polestarApi.auth.latest_call_code != 200:
-            return self.polestarApi.auth.latest_call_code
-        if self.polestarApi.latest_call_code != 200:
-            return self.polestarApi.latest_call_code
-        return self.polestarApi.latest_call_code_2
+        return self.polestar_api.get_latest_data(
+            vin=self.vin, query=query, field_name=field_name
+        )
 
     async def async_update(self) -> None:
         """Update data from Polestar."""
         try:
-            await self.polestarApi.get_ev_data(self.vin)
+            await self.polestar_api.get_ev_data(self.vin)
             return
         except PolestarApiException as e:
             _LOGGER.warning("API Exception on update data %s", str(e))
-            self.polestarApi.next_update = datetime.now() + timedelta(seconds=5)
+            self.a.next_update = datetime.now() + timedelta(seconds=5)
         except PolestarAuthException as e:
             _LOGGER.warning("Auth Exception on update data %s", str(e))
-            self.polestarApi.auth.get_token()
-            self.polestarApi.next_update = datetime.now() + timedelta(seconds=5)
+            await self.polestar_api.auth.get_token()
+            self.polestar_api.next_update = datetime.now() + timedelta(seconds=5)
         except httpx.ConnectTimeout as e:
             _LOGGER.warning("Connection Timeout on update data %s", str(e))
-            self.polestarApi.next_update = datetime.now() + timedelta(seconds=15)
+            self.polestar_api.next_update = datetime.now() + timedelta(seconds=15)
         except httpx.ConnectError as e:
             _LOGGER.warning("Connection Error on update data %s", str(e))
-            self.polestarApi.next_update = datetime.now() + timedelta(seconds=15)
+            self.polestar_api.next_update = datetime.now() + timedelta(seconds=15)
         except httpx.ReadTimeout as e:
             _LOGGER.warning("Read Timeout on update data %s", str(e))
-            self.polestarApi.next_update = datetime.now() + timedelta(seconds=15)
+            self.polestar_api.next_update = datetime.now() + timedelta(seconds=15)
         except Exception as e:
             _LOGGER.error("Unexpected Error on update data %s", str(e))
-            self.polestarApi.next_update = datetime.now() + timedelta(seconds=60)
-        self.polestarApi.latest_call_code_v2 = 500
-        self.polestarApi.updating = False
-
-    def set_config_unit(self, unit: UnitSystem):
-        """Set unit system for the device."""
-        self.unit_system = unit
-
-    def get_config_unit(self):
-        """Get unit system for the device."""
-        return self.unit_system
+            self.polestar_api.next_update = datetime.now() + timedelta(seconds=60)
+        self.polestar_api.latest_call_code_v2 = 500
+        self.polestar_api.updating = False
 
     def get_value(self, query: str, field_name: str, skip_cache: bool = False):
         """Get the latest value from the Polestar API."""
-        data = self.polestarApi.get_cache_data(query, field_name, skip_cache)
+        data = self.polestar_api.get_cache_data(
+            vin=self.vin, query=query, field_name=field_name, skip_cache=skip_cache
+        )
         if data is None:
             # if amp and voltage can be null, so we will return 0
             if field_name in ("chargingCurrentAmps", "chargingPowerWatts"):
                 return 0
             return
         return data
+
+    def get_token_expiry(self):
+        """Get the token expiry time."""
+        return self.polestar_api.auth.token_expiry
+
+    def get_latest_call_code_v1(self):
+        """Get the latest call code mystar API."""
+        return self.polestar_api.latest_call_code
+
+    def get_latest_call_code_v2(self):
+        """Get the latest call code mystar-v2 API."""
+        return self.polestar_api.latest_call_code_2
+
+    def get_latest_call_code_auth(self):
+        """Get the latest call code mystar API."""
+        return self.polestar_api.auth.latest_call_code
+
+    def get_latest_call_code(self):
+        """Get the latest call code."""
+        # if AUTH code last code is not 200 then we return that error code,
+        # otherwise just give the call_code in API from v1 and then v2
+        if self.polestar_api.auth.latest_call_code != 200:
+            return self.polestar_api.auth.latest_call_code
+        if self.polestar_api.latest_call_code != 200:
+            return self.polestar_api.latest_call_code
+        return self.polestar_api.latest_call_code_2
+
+
+class PolestarCoordinator:
+    """Polestar EV integration."""
+
+    def __init__(self, hass: HomeAssistant, username: str, password: str) -> None:
+        """Initialize the Polestar API."""
+        self.polestar_api = PolestarApi(username, password, get_async_client(hass))
+        disable_warnings()
+
+    async def init(self):
+        """Initialize the Polestar API."""
+        await self.polestar_api.init()
+
+    def get_cars(self) -> list[PolestarCar]:
+        return [
+            PolestarCar(api=self.polestar_api, vin=vin)
+            for vin in self.polestar_api.vins
+        ]

--- a/custom_components/polestar_api/polestar.py
+++ b/custom_components/polestar_api/polestar.py
@@ -12,8 +12,6 @@ from .const import DOMAIN as POLESTAR_API_DOMAIN
 from .pypolestar.exception import PolestarApiException, PolestarAuthException
 from .pypolestar.polestar import PolestarApi
 
-POST_HEADER_JSON = {"Content-Type": "application/json"}
-
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/custom_components/polestar_api/polestar.py
+++ b/custom_components/polestar_api/polestar.py
@@ -122,11 +122,18 @@ class PolestarCar:
 class PolestarCoordinator:
     """Polestar EV integration."""
 
-    def __init__(self, hass: HomeAssistant, username: str, password: str) -> None:
+    def __init__(
+        self, hass: HomeAssistant, username: str, password: str, vin: str | None
+    ) -> None:
         """Initialize the Polestar API."""
-        self.polestar_api = PolestarApi(username, password, get_async_client(hass))
+        self.polestar_api = PolestarApi(
+            username=username,
+            password=password,
+            client_session=get_async_client(hass),
+            vins=[vin] if vin else None,
+        )
 
-    async def async_init(self) -> None:
+    async def async_init(self):
         """Initialize the Polestar API."""
         await self.polestar_api.async_init()
 

--- a/custom_components/polestar_api/polestar.py
+++ b/custom_components/polestar_api/polestar.py
@@ -7,7 +7,6 @@ import httpx
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.httpx_client import get_async_client
-from urllib3 import disable_warnings
 
 from .const import DOMAIN as POLESTAR_API_DOMAIN
 from .pypolestar.exception import PolestarApiException, PolestarAuthException
@@ -128,11 +127,10 @@ class PolestarCoordinator:
     def __init__(self, hass: HomeAssistant, username: str, password: str) -> None:
         """Initialize the Polestar API."""
         self.polestar_api = PolestarApi(username, password, get_async_client(hass))
-        disable_warnings()
 
-    async def init(self):
+    async def async_init(self):
         """Initialize the Polestar API."""
-        await self.polestar_api.init()
+        await self.polestar_api.async_init()
 
     def get_cars(self) -> list[PolestarCar]:
         return [

--- a/custom_components/polestar_api/polestar.py
+++ b/custom_components/polestar_api/polestar.py
@@ -92,23 +92,23 @@ class PolestarCar:
             return
         return data
 
-    def get_token_expiry(self):
+    def get_token_expiry(self) -> datetime | None:
         """Get the token expiry time."""
         return self.polestar_api.auth.token_expiry
 
-    def get_latest_call_code_v1(self):
+    def get_latest_call_code_v1(self) -> int | None:
         """Get the latest call code mystar API."""
         return self.polestar_api.latest_call_code
 
-    def get_latest_call_code_v2(self):
+    def get_latest_call_code_v2(self) -> int | None:
         """Get the latest call code mystar-v2 API."""
         return self.polestar_api.latest_call_code_2
 
-    def get_latest_call_code_auth(self):
+    def get_latest_call_code_auth(self) -> int | None:
         """Get the latest call code mystar API."""
         return self.polestar_api.auth.latest_call_code
 
-    def get_latest_call_code(self):
+    def get_latest_call_code(self) -> int | None:
         """Get the latest call code."""
         # if AUTH code last code is not 200 then we return that error code,
         # otherwise just give the call_code in API from v1 and then v2
@@ -126,7 +126,7 @@ class PolestarCoordinator:
         """Initialize the Polestar API."""
         self.polestar_api = PolestarApi(username, password, get_async_client(hass))
 
-    async def async_init(self):
+    async def async_init(self) -> None:
         """Initialize the Polestar API."""
         await self.polestar_api.async_init()
 

--- a/custom_components/polestar_api/polestar.py
+++ b/custom_components/polestar_api/polestar.py
@@ -60,7 +60,7 @@ class PolestarCar:
             return
         except PolestarApiException as e:
             _LOGGER.warning("API Exception on update data %s", str(e))
-            self.a.next_update = datetime.now() + timedelta(seconds=5)
+            self.polestar_api.next_update = datetime.now() + timedelta(seconds=5)
         except PolestarAuthException as e:
             _LOGGER.warning("Auth Exception on update data %s", str(e))
             await self.polestar_api.auth.get_token()

--- a/custom_components/polestar_api/pypolestar/polestar.py
+++ b/custom_components/polestar_api/pypolestar/polestar.py
@@ -88,7 +88,7 @@ class PolestarApi:
             return self._get_field_name_value(field_name, data)
         return None
 
-    async def get_ev_data(self, vin: str):
+    async def get_ev_data(self, vin: str) -> None:
         """Get the latest ev data from the Polestar API."""
         if self.updating:
             return
@@ -127,7 +127,7 @@ class PolestarApi:
 
     def get_cache_data(
         self, vin: str, query: str, field_name: str, skip_cache: bool = False
-    ):
+    ) -> dict | None:
         """Get the latest data from the cache."""
         if query is None:
             return None
@@ -161,7 +161,7 @@ class PolestarApi:
 
         return None
 
-    async def _get_odometer_data(self, vin: str):
+    async def _get_odometer_data(self, vin: str) -> None:
         """Get the latest odometer data from the Polestar API."""
         params = {
             "query": "query GetOdometerData($vin:String!){getOdometerData(vin:$vin){averageSpeedKmPerHour eventUpdatedTimestamp{iso unix}odometerMeters tripMeterAutomaticKm tripMeterManualKm}}",
@@ -177,7 +177,7 @@ class PolestarApi:
                 "timestamp": datetime.now(),
             }
 
-    async def _get_battery_data(self, vin: str):
+    async def _get_battery_data(self, vin: str) -> None:
         params = {
             "query": "query GetBatteryData($vin:String!){getBatteryData(vin:$vin){averageEnergyConsumptionKwhPer100Km batteryChargeLevelPercentage chargerConnectionStatus chargingCurrentAmps chargingPowerWatts chargingStatus estimatedChargingTimeMinutesToTargetDistance estimatedChargingTimeToFullMinutes estimatedDistanceToEmptyKm estimatedDistanceToEmptyMiles eventUpdatedTimestamp{iso unix}}}",
             "operationName": "GetBatteryData",
@@ -193,7 +193,7 @@ class PolestarApi:
                 "timestamp": datetime.now(),
             }
 
-    async def _get_vehicle_data(self):
+    async def _get_vehicle_data(self) -> dict | None:
         """Get the latest vehicle data from the Polestar API."""
         # get Vehicle Data
         params = {
@@ -216,7 +216,7 @@ class PolestarApi:
             return result["data"][CAR_INFO_DATA]
         return None
 
-    def _set_latest_call_code(self, url: str, code: int):
+    def _set_latest_call_code(self, url: str, code: int) -> None:
         if url == BASE_URL:
             self.latest_call_code = code
         else:

--- a/custom_components/polestar_api/pypolestar/polestar.py
+++ b/custom_components/polestar_api/pypolestar/polestar.py
@@ -45,7 +45,7 @@ class PolestarApi:
         self.car_data_by_vin: dict[str, dict] = {}
         self.cache_data_by_vin: dict[str, dict] = defaultdict(dict)
 
-    async def init(self):
+    async def async_init(self):
         """Initialize the Polestar API."""
         try:
             await self.auth.init()

--- a/custom_components/polestar_api/pypolestar/polestar.py
+++ b/custom_components/polestar_api/pypolestar/polestar.py
@@ -1,5 +1,6 @@
 """Asynchronous Python client for the Polestar API.""" ""
 
+import json
 import logging
 from collections import defaultdict
 from datetime import datetime, timedelta
@@ -233,6 +234,9 @@ class PolestarApi:
             "authorization": f"Bearer {self.auth.access_token}",
         }
 
+        _LOGGER.debug("GraphQL URL: %s", url)
+        _LOGGER.debug("GraphQL Query: %s", json.dumps(params))
+
         result = await self.client_session.get(url, params=params, headers=headers)
         self._set_latest_call_code(url, result.status_code)
 
@@ -248,8 +252,8 @@ class PolestarApi:
             error_message = resultData["errors"][0]["message"]
             if error_message == "User not authenticated":
                 raise PolestarNotAuthorizedException("Unauthorized Exception")
-            _LOGGER.error(resultData.get("errors"))
+            _LOGGER.error("Error: %s", resultData.get("errors"))
             raise PolestarApiException(error_message)
 
-        _LOGGER.debug(resultData)
+        _LOGGER.debug("GraphQL Result: %s", json.dumps(resultData))
         return resultData

--- a/custom_components/polestar_api/pypolestar/polestar.py
+++ b/custom_components/polestar_api/pypolestar/polestar.py
@@ -83,83 +83,6 @@ class PolestarApi:
             return self._get_field_name_value(field_name, data)
         return None
 
-    def _get_field_name_value(self, field_name: str, data: dict) -> str or bool or None:
-        if field_name is None or data is None:
-            return None
-
-        if "/" in field_name:
-            field_names = field_name.split("/")
-            for key in field_names:
-                if isinstance(data, dict) and key in data:
-                    data = data[key]
-                else:
-                    return None
-            return data
-
-        if isinstance(data, dict) and field_name in data:
-            return data[field_name]
-
-        return None
-
-    async def _get_odometer_data(self, vin: str):
-        """Get the latest odometer data from the Polestar API."""
-        params = {
-            "query": "query GetOdometerData($vin:String!){getOdometerData(vin:$vin){averageSpeedKmPerHour eventUpdatedTimestamp{iso unix}odometerMeters tripMeterAutomaticKm tripMeterManualKm}}",
-            "operationName": "GetOdometerData",
-            "variables": '{"vin":"' + vin + '"}',
-        }
-        result = await self.get_graph_ql(params, BASE_URL_V2)
-
-        if result and result["data"]:
-            # put result in cache
-            self.cache_data[ODO_METER_DATA] = {
-                "data": result["data"][ODO_METER_DATA],
-                "timestamp": datetime.now(),
-            }
-
-    async def _get_battery_data(self, vin: str):
-        params = {
-            "query": "query GetBatteryData($vin:String!){getBatteryData(vin:$vin){averageEnergyConsumptionKwhPer100Km batteryChargeLevelPercentage chargerConnectionStatus chargingCurrentAmps chargingPowerWatts chargingStatus estimatedChargingTimeMinutesToTargetDistance estimatedChargingTimeToFullMinutes estimatedDistanceToEmptyKm estimatedDistanceToEmptyMiles eventUpdatedTimestamp{iso unix}}}",
-            "operationName": "GetBatteryData",
-            "variables": '{"vin":"' + vin + '"}',
-        }
-
-        result = await self.get_graph_ql(params, BASE_URL_V2)
-
-        if result and result["data"]:
-            # put result in cache
-            self.cache_data[BATTERY_DATA] = {
-                "data": result["data"][BATTERY_DATA],
-                "timestamp": datetime.now(),
-            }
-
-    async def _get_vehicle_data(self):
-        """Get the latest vehicle data from the Polestar API."""
-        # get Vehicle Data
-        params = {
-            "query": "query GetConsumerCarsV2 { getConsumerCarsV2 { vin internalVehicleIdentifier salesType currentPlannedDeliveryDate market originalMarket pno34 modelYear registrationNo metaOrderNumber factoryCompleteDate registrationDate deliveryDate serviceHistory { claimType market mileage mileageUnit operations { id code description quantity performedDate } orderEndDate orderNumber orderStartDate parts { id code description quantity performedDate } statusDMS symptomCode vehicleAge workshopId } content { exterior { code name description excluded } exteriorDetails { code name description excluded } interior { code name description excluded } performancePackage { code name description excluded } performanceOptimizationSpecification { power { value unit } torqueMax { value unit } acceleration { value unit description } } wheels { code name description excluded } plusPackage { code name description excluded } pilotPackage { code name description excluded } motor { name description excluded } model { name code } images { studio { url angles resolutions } location { url angles resolutions } interior { url angles resolutions } } specification { battery bodyType brakes combustionEngine electricMotors performance suspension tireSizes torque totalHp totalKw trunkCapacity { label value } } dimensions { wheelbase { label value } groundClearanceWithPerformance { label value } groundClearanceWithoutPerformance { label value } dimensions { label value } } towbar { code name description excluded } } primaryDriver primaryDriverRegistrationTimestamp owners { id registeredAt information { polestarId ownerType } } wltpNedcData { wltpCO2Unit wltpElecEnergyConsumption wltpElecEnergyUnit wltpElecRange wltpElecRangeUnit wltpWeightedCombinedCO2 wltpWeightedCombinedFuelConsumption wltpWeightedCombinedFuelConsumptionUnit } energy { elecRange elecRangeUnit elecEnergyConsumption elecEnergyUnit weightedCombinedCO2 weightedCombinedCO2Unit weightedCombinedFuelConsumption weightedCombinedFuelConsumptionUnit } fuelType drivetrain numberOfDoors numberOfSeats motor { description code } maxTrailerWeight { value unit } curbWeight { value unit } hasPerformancePackage numberOfCylinders cylinderVolume cylinderVolumeUnit transmission numberOfGears structureWeek software { version versionTimestamp performanceOptimization { value description timestamp } } latestClaimStatus { mileage mileageUnit registeredDate vehicleAge } internalCar { origin registeredAt } edition commonStatusPoint { code timestamp description } brandStatus { code timestamp description } intermediateDestinationCode partnerDestinationCode features { type code name description excluded galleryImage { url alt } thumbnail { url alt } } electricalEngineNumbers { number placement } } }",
-            "operationName": "GetConsumerCarsV2",
-            "variables": '{"locale":"en_GB"}',
-        }
-
-        result = await self.get_graph_ql(params)
-        if result and result["data"]:
-            # check if there are cars in the account
-            if (
-                result["data"][CAR_INFO_DATA] is None
-                or len(result["data"][CAR_INFO_DATA]) == 0
-            ):
-                _LOGGER.exception("No cars found in account")
-                # throw new exception
-                raise PolestarNoDataException("No cars found in account")
-
-            return result["data"][CAR_INFO_DATA]
-            # self.cache_data[CAR_INFO_DATA] = {
-            #     "data": result["data"][CAR_INFO_DATA][0],
-            #     "timestamp": datetime.now(),
-            # }
-        return None
-
     async def get_ev_data(self, vin: str):
         """Get the latest ev data from the Polestar API."""
         if self.updating:
@@ -213,13 +136,90 @@ class PolestarApi:
                 return self._get_field_name_value(field_name, data)
         return None
 
+    def _get_field_name_value(self, field_name: str, data: dict) -> str or bool or None:
+        if field_name is None or data is None:
+            return None
+
+        if "/" in field_name:
+            field_names = field_name.split("/")
+            for key in field_names:
+                if isinstance(data, dict) and key in data:
+                    data = data[key]
+                else:
+                    return None
+            return data
+
+        if isinstance(data, dict) and field_name in data:
+            return data[field_name]
+
+        return None
+
+    async def _get_odometer_data(self, vin: str):
+        """Get the latest odometer data from the Polestar API."""
+        params = {
+            "query": "query GetOdometerData($vin:String!){getOdometerData(vin:$vin){averageSpeedKmPerHour eventUpdatedTimestamp{iso unix}odometerMeters tripMeterAutomaticKm tripMeterManualKm}}",
+            "operationName": "GetOdometerData",
+            "variables": '{"vin":"' + vin + '"}',
+        }
+        result = await self._get_graph_ql(params, BASE_URL_V2)
+
+        if result and result["data"]:
+            # put result in cache
+            self.cache_data[ODO_METER_DATA] = {
+                "data": result["data"][ODO_METER_DATA],
+                "timestamp": datetime.now(),
+            }
+
+    async def _get_battery_data(self, vin: str):
+        params = {
+            "query": "query GetBatteryData($vin:String!){getBatteryData(vin:$vin){averageEnergyConsumptionKwhPer100Km batteryChargeLevelPercentage chargerConnectionStatus chargingCurrentAmps chargingPowerWatts chargingStatus estimatedChargingTimeMinutesToTargetDistance estimatedChargingTimeToFullMinutes estimatedDistanceToEmptyKm estimatedDistanceToEmptyMiles eventUpdatedTimestamp{iso unix}}}",
+            "operationName": "GetBatteryData",
+            "variables": '{"vin":"' + vin + '"}',
+        }
+
+        result = await self._get_graph_ql(params, BASE_URL_V2)
+
+        if result and result["data"]:
+            # put result in cache
+            self.cache_data[BATTERY_DATA] = {
+                "data": result["data"][BATTERY_DATA],
+                "timestamp": datetime.now(),
+            }
+
+    async def _get_vehicle_data(self):
+        """Get the latest vehicle data from the Polestar API."""
+        # get Vehicle Data
+        params = {
+            "query": "query GetConsumerCarsV2 { getConsumerCarsV2 { vin internalVehicleIdentifier salesType currentPlannedDeliveryDate market originalMarket pno34 modelYear registrationNo metaOrderNumber factoryCompleteDate registrationDate deliveryDate serviceHistory { claimType market mileage mileageUnit operations { id code description quantity performedDate } orderEndDate orderNumber orderStartDate parts { id code description quantity performedDate } statusDMS symptomCode vehicleAge workshopId } content { exterior { code name description excluded } exteriorDetails { code name description excluded } interior { code name description excluded } performancePackage { code name description excluded } performanceOptimizationSpecification { power { value unit } torqueMax { value unit } acceleration { value unit description } } wheels { code name description excluded } plusPackage { code name description excluded } pilotPackage { code name description excluded } motor { name description excluded } model { name code } images { studio { url angles resolutions } location { url angles resolutions } interior { url angles resolutions } } specification { battery bodyType brakes combustionEngine electricMotors performance suspension tireSizes torque totalHp totalKw trunkCapacity { label value } } dimensions { wheelbase { label value } groundClearanceWithPerformance { label value } groundClearanceWithoutPerformance { label value } dimensions { label value } } towbar { code name description excluded } } primaryDriver primaryDriverRegistrationTimestamp owners { id registeredAt information { polestarId ownerType } } wltpNedcData { wltpCO2Unit wltpElecEnergyConsumption wltpElecEnergyUnit wltpElecRange wltpElecRangeUnit wltpWeightedCombinedCO2 wltpWeightedCombinedFuelConsumption wltpWeightedCombinedFuelConsumptionUnit } energy { elecRange elecRangeUnit elecEnergyConsumption elecEnergyUnit weightedCombinedCO2 weightedCombinedCO2Unit weightedCombinedFuelConsumption weightedCombinedFuelConsumptionUnit } fuelType drivetrain numberOfDoors numberOfSeats motor { description code } maxTrailerWeight { value unit } curbWeight { value unit } hasPerformancePackage numberOfCylinders cylinderVolume cylinderVolumeUnit transmission numberOfGears structureWeek software { version versionTimestamp performanceOptimization { value description timestamp } } latestClaimStatus { mileage mileageUnit registeredDate vehicleAge } internalCar { origin registeredAt } edition commonStatusPoint { code timestamp description } brandStatus { code timestamp description } intermediateDestinationCode partnerDestinationCode features { type code name description excluded galleryImage { url alt } thumbnail { url alt } } electricalEngineNumbers { number placement } } }",
+            "operationName": "GetConsumerCarsV2",
+            "variables": '{"locale":"en_GB"}',
+        }
+
+        result = await self._get_graph_ql(params)
+        if result and result["data"]:
+            # check if there are cars in the account
+            if (
+                result["data"][CAR_INFO_DATA] is None
+                or len(result["data"][CAR_INFO_DATA]) == 0
+            ):
+                _LOGGER.exception("No cars found in account")
+                # throw new exception
+                raise PolestarNoDataException("No cars found in account")
+
+            return result["data"][CAR_INFO_DATA]
+            # self.cache_data[CAR_INFO_DATA] = {
+            #     "data": result["data"][CAR_INFO_DATA][0],
+            #     "timestamp": datetime.now(),
+            # }
+        return None
+
     def _set_latest_call_code(self, url: str, code: int):
         if url == BASE_URL:
             self.latest_call_code = code
         else:
             self.latest_call_code_2 = code
 
-    async def get_graph_ql(self, params: dict, url: str = BASE_URL):
+    async def _get_graph_ql(self, params: dict, url: str = BASE_URL):
         """Get the latest data from the Polestar API."""
         headers = {
             "Content-Type": "application/json",

--- a/custom_components/polestar_api/pypolestar/polestar.py
+++ b/custom_components/polestar_api/pypolestar/polestar.py
@@ -141,7 +141,8 @@ class PolestarApi:
                 return self._get_field_name_value(field_name, data)
         return None
 
-    def _get_field_name_value(self, field_name: str, data: dict) -> str or bool or None:
+    @staticmethod
+    def _get_field_name_value(field_name: str, data: dict) -> str or bool or None:
         if field_name is None or data is None:
             return None
 

--- a/custom_components/polestar_api/sensor.py
+++ b/custom_components/polestar_api/sensor.py
@@ -34,7 +34,7 @@ from homeassistant.util.unit_conversion import (
 
 from . import DOMAIN as POLESTAR_API_DOMAIN
 from .entity import PolestarEntity
-from .polestar import Polestar
+from .polestar import PolestarCar
 
 _LOGGER = logging.getLogger(__name__)
 SCAN_INTERVAL = timedelta(seconds=15)
@@ -491,10 +491,8 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ):
     """Set up using config_entry."""
-    devices: list[Polestar] = hass.data[POLESTAR_API_DOMAIN][entry.entry_id]
+    devices: list[PolestarCar] = hass.data[POLESTAR_API_DOMAIN][entry.entry_id]
     for device in devices:
-        # put data in cache
-        await device.async_update()
         sensors = [
             PolestarSensor(device, description) for description in POLESTAR_SENSOR_TYPES
         ]
@@ -510,7 +508,7 @@ class PolestarSensor(PolestarEntity, SensorEntity):
     _attr_has_entity_name = True
 
     def __init__(
-        self, device: Polestar, description: PolestarSensorDescription
+        self, device: PolestarCar, description: PolestarSensorDescription
     ) -> None:
         """Initialize the sensor."""
         super().__init__(device)
@@ -745,4 +743,6 @@ class PolestarSensor(PolestarEntity, SensorEntity):
 
         except Exception:
             _LOGGER.warning("Failed to update sensor async update")
-            self.device.polestarApi.next_update = datetime.now() + timedelta(seconds=60)
+            self.device.polestar_api.next_update = datetime.now() + timedelta(
+                seconds=60
+            )

--- a/custom_components/polestar_api/translations/da.json
+++ b/custom_components/polestar_api/translations/da.json
@@ -7,7 +7,8 @@
         "data": {
           "name": "Visningsnavn",
           "username": "Polestar ID",
-          "password": "Adgangskode"
+          "password": "Adgangskode",
+          "vin": "VIN"
         }
       }
     },

--- a/custom_components/polestar_api/translations/de.json
+++ b/custom_components/polestar_api/translations/de.json
@@ -7,7 +7,8 @@
         "data": {
           "name": "Anzeigename",
           "username": "Benutzername",
-          "password": "Passwort"
+          "password": "Passwort",
+          "vin": "VIN"
         }
       }
     },

--- a/custom_components/polestar_api/translations/en.json
+++ b/custom_components/polestar_api/translations/en.json
@@ -6,7 +6,8 @@
         "description": "Enter Authentication of Polestar EV",
         "data": {
           "username": "Username",
-          "password": "Password"
+          "password": "Password",
+          "vin": "VIN"
         }
       }
     },

--- a/custom_components/polestar_api/translations/fr.json
+++ b/custom_components/polestar_api/translations/fr.json
@@ -6,7 +6,8 @@
         "description": "Entrez les paramètres d'authentification pour Polestar",
         "data": {
           "username": "Nom d'utilisateur",
-          "password": "Mot de passe"
+          "password": "Mot de passe",
+          "vin": "VIN"
         }
       }
     },

--- a/custom_components/polestar_api/translations/ko.json
+++ b/custom_components/polestar_api/translations/ko.json
@@ -6,7 +6,8 @@
         "description": "폴스타 API 연동을 위해 필요한 인증 정보를 입력하세요.",
         "data": {
           "username": "Polestar ID",
-          "password": "비밀번호"
+          "password": "비밀번호",
+          "vin": "VIN"
         }
       }
     },

--- a/custom_components/polestar_api/translations/nl.json
+++ b/custom_components/polestar_api/translations/nl.json
@@ -6,7 +6,8 @@
         "description": "Vul authenticatie voor Polestar EV",
         "data": {
           "username": "Gebruikersnaam",
-          "password": "Wachtwoord"
+          "password": "Wachtwoord",
+          "vin": "VIN"
         }
       }
     },


### PR DESCRIPTION
Split `Polestar` into one `PolestarCoordinator` per username and one `PolestarCar` per car. All calls to `PolestarApi` now requires a VIN and all data is cached by VIN.

Also allow specifying VIN when setting up integration. If specified, the integration will configure only the specified VIN only and ignore all other cars. Default is to import all cars.

Closes #182