### PR TITLE
Refactor and simplify

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,41 @@
+{
+    "name": "pypolestar/polestar_api",
+    "image": "mcr.microsoft.com/devcontainers/python:3.12",
+    "postCreateCommand": "scripts/setup",
+    "forwardPorts": [
+        8123
+    ],
+    "portsAttributes": {
+        "8123": {
+            "label": "Home Assistant",
+            "onAutoForward": "notify"
+        }
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "charliermarsh.ruff",
+                "github.vscode-pull-request-github",
+                "ms-python.python",
+                "ms-python.vscode-pylance",
+                "ryanluker.vscode-coverage-gutters"
+            ],
+            "settings": {
+                "files.eol": "\n",
+                "editor.tabSize": 4,
+                "editor.formatOnPaste": true,
+                "editor.formatOnSave": true,
+                "editor.formatOnType": false,
+                "files.trimTrailingWhitespace": true,
+                "python.analysis.typeCheckingMode": "basic",
+                "python.analysis.autoImportCompletions": true,
+                "python.defaultInterpreterPath": "/usr/local/bin/python",
+                "[python]": {
+                    "editor.defaultFormatter": "charliermarsh.ruff"
+                }
+            }
+        }
+    },
+    "remoteUser": "vscode",
+    "features": {}
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "ruff.lineLength": 88,
-    "editor.defaultFormatter": "charliermarsh.ruff"
-}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,11 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Run Home Assistant on port 8123",
+            "type": "shell",
+            "command": "scripts/develop",
+            "problemMatcher": []
+        }
+    ]
+}

--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -1,0 +1,9 @@
+# https://www.home-assistant.io/integrations/homeassistant/
+homeassistant:
+  debug: true
+
+# https://www.home-assistant.io/integrations/logger/
+logger:
+  default: info
+  logs:
+    custom_components.polestar_api: debug

--- a/custom_components/polestar_api/__init__.py
+++ b/custom_components/polestar_api/__init__.py
@@ -27,6 +27,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: PolestarConfigEntry) -> 
         username=entry.data[CONF_USERNAME],
         password=entry.data[CONF_PASSWORD],
         vin=entry.data.get(CONF_VIN),
+        unique_id=entry.entry_id,
     )
 
     try:
@@ -36,7 +37,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: PolestarConfigEntry) -> 
         for car in coordinator.get_cars():
             await car.async_update()
             cars.append(car)
-            _LOGGER.debug("Added car with VIN %s", car.vin)
+            _LOGGER.debug(
+                "Added car with VIN %s for %s",
+                car.vin,
+                entry.entry_id,
+            )
 
         entry.runtime_data = PolestarData(
             coordinator=coordinator,

--- a/custom_components/polestar_api/config_flow.py
+++ b/custom_components/polestar_api/config_flow.py
@@ -28,7 +28,7 @@ class FlowHandler(config_entries.ConfigFlow):
     ) -> ConfigFlowResult:
         """Register new entry."""
         return self.async_create_entry(
-            title="Polestar EV",
+            title=f"Polestar EV for {username}",
             data={CONF_USERNAME: username, CONF_PASSWORD: password, CONF_VIN: vin},
         )
 

--- a/custom_components/polestar_api/data.py
+++ b/custom_components/polestar_api/data.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.loader import Integration
+
+from .polestar import PolestarCar, PolestarCoordinator
+
+type PolestarConfigEntry = ConfigEntry[PolestarData]
+
+
+@dataclass
+class PolestarData:
+    coordinator: PolestarCoordinator
+    cars: list[PolestarCar]
+    integration: Integration

--- a/custom_components/polestar_api/entity.py
+++ b/custom_components/polestar_api/entity.py
@@ -12,14 +12,9 @@ _LOGGER = logging.getLogger(__name__)
 class PolestarEntity(Entity):
     """Base class for Polestar entities."""
 
-    def __init__(self, device: PolestarCar) -> None:
+    def __init__(self, car: PolestarCar) -> None:
         """Initialize the Polestar entity."""
-        self.device = device
-        self._attr_device_info = device.get_device_info()
-
-    def get_device(self):
-        """Return the device."""
-        return self.device
+        self._attr_device_info = car.get_device_info()
 
     async def async_added_to_hass(self) -> None:
         """Add listener for state changes."""

--- a/custom_components/polestar_api/image.py
+++ b/custom_components/polestar_api/image.py
@@ -9,12 +9,11 @@ from functools import cached_property
 from typing import Final
 
 from homeassistant.components.image import ImageEntity, ImageEntityDescription
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import DOMAIN as POLESTAR_API_DOMAIN
+from .const import DOMAIN as POLESTAR_API_DOMAIN
+from .data import PolestarConfigEntry
 from .entity import PolestarEntity
 from .polestar import PolestarCar
 
@@ -36,27 +35,29 @@ class PolestarImageDescription(ImageEntityDescription, PolestarImageDescriptionM
 
 POLESTAR_IMAGE_TYPES: Final[tuple[PolestarImageDescription, ...]] = (
     PolestarImageDescription(
+        key="car_image",
+        name="Car Image",
         query="getConsumerCarsV2",
         field_name="content/images/studio/url",
-        key="car_image",
         entity_registry_enabled_default=False,
     ),
 )
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: PolestarConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Polestar image entities based on a config entry."""
 
-    devices: list[PolestarCar] = hass.data[POLESTAR_API_DOMAIN][entry.entry_id]
-    for device in devices:
-        images = [
-            PolestarImage(device, description, hass)
-            for description in POLESTAR_IMAGE_TYPES
+    async_add_entities(
+        [
+            PolestarImage(car, entity_description, hass)
+            for entity_description in POLESTAR_IMAGE_TYPES
+            for car in entry.runtime_data.cars
         ]
-        async_add_entities(images)
-    entity_platform.current_platform.get()
+    )
 
 
 class PolestarImage(PolestarEntity, ImageEntity):
@@ -66,25 +67,25 @@ class PolestarImage(PolestarEntity, ImageEntity):
 
     def __init__(
         self,
-        device: PolestarCar,
-        description: PolestarImageDescription,
+        car: PolestarCar,
+        entity_description: PolestarImageDescription,
         hass: HomeAssistant,
     ) -> None:
         """Initialize the Polestar image."""
-        super().__init__(device)
+        super().__init__(car)
         ImageEntity.__init__(self, hass)
-        unique_id = device.get_unique_id()
-        self.entity_id = (
-            f"{POLESTAR_API_DOMAIN}.'polestar_'.{unique_id}_{description.key}"
+        self.car = car
+        self.entity_description = entity_description
+        self.entity_id = f"{POLESTAR_API_DOMAIN}.'polestar_'.{car.get_short_id()}_{entity_description.key}"
+        self._attr_unique_id = (
+            f"polestar_{car.get_unique_id()}_{entity_description.key}"
         )
-        self._attr_unique_id = f"polestar_{unique_id}-{description.key}"
-        self.entity_description = description
-        self._attr_translation_key = f"polestar_{description.key}"
+        self._attr_translation_key = f"polestar_{entity_description.key}"
         self._attr_image_last_updated = datetime.datetime.now()
 
     @cached_property
     def image_url(self) -> str | None:
         """Return the image URL."""
-        return self.device.get_value(
+        return self.car.get_value(
             self.entity_description.query, self.entity_description.field_name
         )

--- a/custom_components/polestar_api/image.py
+++ b/custom_components/polestar_api/image.py
@@ -64,6 +64,7 @@ class PolestarImage(PolestarEntity, ImageEntity):
     """Representation of a Polestar image."""
 
     entity_description: PolestarImageDescription
+    _attr_has_entity_name = True
 
     def __init__(
         self,

--- a/custom_components/polestar_api/polestar.py
+++ b/custom_components/polestar_api/polestar.py
@@ -138,13 +138,14 @@ class PolestarCoordinator:
             _LOGGER.debug("Configure Polestar API client for car with VIN %s", vin)
         else:
             _LOGGER.debug("Configure Polestar API client for all cars")
+        self.unique_id = unique_id
         self.polestar_api = PolestarApi(
             username=username,
             password=password,
             client_session=get_async_client(hass),
             vins=[vin] if vin else None,
+            unique_id=self.unique_id,
         )
-        self.unique_id = unique_id
 
     async def async_init(self):
         """Initialize the Polestar API."""

--- a/custom_components/polestar_api/polestar.py
+++ b/custom_components/polestar_api/polestar.py
@@ -26,13 +26,19 @@ class PolestarCar:
         """Initialize the Polestar Car."""
         self.polestar_api = api
         self.vin = vin
-        self.name = "Polestar " + self.get_unique_id()
-        self.model = (
+        self.name = "Polestar " + self.get_short_id()
+        self.model = str(
             self.get_value("getConsumerCarsV2", "content/model/name") or "Unknown model"
         )
 
     def get_unique_id(self) -> str:
-        """Last 4 character of the VIN"""
+        """Return unique identifier (VIN)"""
+        if self.vin is None:
+            raise UnknownVIN
+        return self.vin.lower()
+
+    def get_short_id(self) -> str:
+        """Last 4 characters of the VIN"""
         if self.vin is None:
             raise UnknownVIN
         return self.vin[-4:]
@@ -40,7 +46,7 @@ class PolestarCar:
     def get_device_info(self) -> DeviceInfo:
         """Return DeviceInfo for current device"""
         return DeviceInfo(
-            identifiers={(POLESTAR_API_DOMAIN, self.vin)},
+            identifiers={(POLESTAR_API_DOMAIN, self.get_unique_id())},
             manufacturer="Polestar",
             model=self.model,
             name=self.name,

--- a/custom_components/polestar_api/pypolestar/auth.py
+++ b/custom_components/polestar_api/pypolestar/auth.py
@@ -85,7 +85,7 @@ class PolestarAuth:
         if result.status_code != 200 or (
             "errors" in resultData and len(resultData["errors"])
         ):
-            _LOGGER.error("Auth Token Error: %s", result)
+            _LOGGER.error("Auth Token Error: %s", result.text)
             raise PolestarAuthException("Error getting token", result.status_code)
         _LOGGER.debug("Auth Token Result: %s", json.dumps(resultData))
 

--- a/custom_components/polestar_api/pypolestar/auth.py
+++ b/custom_components/polestar_api/pypolestar/auth.py
@@ -34,7 +34,7 @@ class PolestarAuth:
         self.latest_call_code = None
         self.oidc_configuration = {}
 
-    async def init(self) -> None:
+    async def async_init(self) -> None:
         await self.update_oidc_configuration()
 
     async def update_oidc_configuration(self) -> None:

--- a/custom_components/polestar_api/pypolestar/polestar.py
+++ b/custom_components/polestar_api/pypolestar/polestar.py
@@ -54,7 +54,7 @@ class PolestarApi:
 
     async def async_init(self) -> None:
         """Initialize the Polestar API."""
-        await self.auth.init()
+        await self.auth.async_init()
         await self.auth.get_token()
 
         if self.auth.access_token is None:

--- a/custom_components/polestar_api/pypolestar/polestar.py
+++ b/custom_components/polestar_api/pypolestar/polestar.py
@@ -35,6 +35,7 @@ class PolestarApi:
         password: str,
         client_session: httpx.AsyncClient | None = None,
         vins: list[str] | None = None,
+        unique_id: str | None = None,
     ) -> None:
         """Initialize the Polestar API."""
         self.client_session = client_session or httpx.AsyncClient()
@@ -49,6 +50,7 @@ class PolestarApi:
         self.cache_ttl = timedelta(seconds=CACHE_TIME)
         self.next_update_delay = timedelta(seconds=5)
         self.configured_vins = set(vins) if vins else None
+        self.logger = _LOGGER.getChild(unique_id) if unique_id else _LOGGER
 
     async def async_init(self) -> None:
         """Initialize the Polestar API."""
@@ -56,11 +58,11 @@ class PolestarApi:
         await self.auth.get_token()
 
         if self.auth.access_token is None:
-            _LOGGER.warning("No access token %s", self.username)
+            self.logger.warning("No access token %s", self.username)
             return
 
         if not (car_data := await self._get_vehicle_data()):
-            _LOGGER.warning("No cars found for %s", self.username)
+            self.logger.warning("No cars found for %s", self.username)
             return
 
         for data in car_data:
@@ -72,7 +74,7 @@ class PolestarApi:
                 "data": self.car_data_by_vin[vin],
                 "timestamp": datetime.now(),
             }
-            _LOGGER.debug("API setup for VIN %s", vin)
+            self.logger.debug("API setup for VIN %s", vin)
 
     @property
     def vins(self) -> list[str]:
@@ -95,7 +97,7 @@ class PolestarApi:
             return
 
         if self.next_update is not None and self.next_update > datetime.now():
-            _LOGGER.debug("Skipping update, next update at %s", self.next_update)
+            self.logger.debug("Skipping update, next update at %s", self.next_update)
             return
 
         self.updating = True
@@ -107,7 +109,7 @@ class PolestarApi:
                 await self.auth.get_token(refresh=True)
         except PolestarAuthException as e:
             self._set_latest_call_code(BASE_URL, 500)
-            _LOGGER.warning("Auth Exception: %s", str(e))
+            self.logger.warning("Auth Exception: %s", str(e))
             self.updating = False
             return
 
@@ -118,7 +120,7 @@ class PolestarApi:
                 await self.auth.get_token()
             except PolestarApiException as e:
                 self._set_latest_call_code(BASE_URL_V2, 500)
-                _LOGGER.warning("Failed to get %s data %s", func.__name__, str(e))
+                self.logger.warning("Failed to get %s data %s", func.__name__, str(e))
 
         await call_api(lambda: self._get_odometer_data(vin))
         await call_api(lambda: self._get_battery_data(vin))
@@ -132,7 +134,7 @@ class PolestarApi:
         """Get the latest data from the cache."""
         if query is None:
             return None
-        _LOGGER.debug("get_cache_data %s %s", query, field_name)
+        self.logger.debug("get_cache_data %s %s %s", vin, query, field_name)
         if self.cache_data_by_vin and self.cache_data_by_vin[vin].get(query):
             cache_entry = self.cache_data_by_vin[vin][query]
             data = cache_entry["data"]
@@ -210,7 +212,7 @@ class PolestarApi:
                 result["data"][CAR_INFO_DATA] is None
                 or len(result["data"][CAR_INFO_DATA]) == 0
             ):
-                _LOGGER.exception("No cars found in account")
+                self.logger.exception("No cars found in account")
                 # throw new exception
                 raise PolestarNoDataException("No cars found in account")
 
@@ -230,8 +232,8 @@ class PolestarApi:
             "authorization": f"Bearer {self.auth.access_token}",
         }
 
-        _LOGGER.debug("GraphQL URL: %s", url)
-        _LOGGER.debug("GraphQL Query: %s", json.dumps(params))
+        self.logger.debug("GraphQL URL: %s", url)
+        self.logger.debug("GraphQL Query: %s", json.dumps(params))
 
         result = await self.client_session.get(url, params=params, headers=headers)
         self._set_latest_call_code(url, result.status_code)
@@ -248,8 +250,8 @@ class PolestarApi:
             error_message = resultData["errors"][0]["message"]
             if error_message == "User not authenticated":
                 raise PolestarNotAuthorizedException("Unauthorized Exception")
-            _LOGGER.error("Error: %s", resultData.get("errors"))
+            self.logger.error("Error: %s", resultData.get("errors"))
             raise PolestarApiException(error_message)
 
-        _LOGGER.debug("GraphQL Result: %s", json.dumps(resultData))
+        self.logger.debug("GraphQL Result: %s", json.dumps(resultData))
         return resultData

--- a/custom_components/polestar_api/translations/en.json
+++ b/custom_components/polestar_api/translations/en.json
@@ -88,6 +88,9 @@
       },
       "polestar_api_token_expires_at": {
         "name": "API Token Expires At"
+      },
+      "polestar_car_image": {
+        "name": "Car Image"
       }
     }
   }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,14 @@
+# docker compose to help testing custom integration
+
+services:
+  hass:
+    image: ghcr.io/home-assistant/home-assistant:latest
+    volumes:
+      - hass_config:/config
+      - ./config/configuration.yaml:/config/configuration.yaml:ro
+      - ./custom_components:/config/custom_components:ro
+    ports:
+       - "8123:8123/tcp"
+
+volumes:
+  hass_config:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+colorlog==6.8.2
+homeassistant==2024.6.0
+pip>=21.3.1
+ruff==0.7.1

--- a/scripts/develop
+++ b/scripts/develop
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+# Create config dir if not present
+if [[ ! -d "${PWD}/config" ]]; then
+    mkdir -p "${PWD}/config"
+    hass --config "${PWD}/config" --script ensure_config
+fi
+
+# Set the path to custom_components
+## This let's us have the structure we want <root>/custom_components/integration_blueprint
+## while at the same time have Home Assistant configuration inside <root>/config
+## without resulting to symlinks.
+export PYTHONPATH="${PYTHONPATH}:${PWD}/custom_components"
+
+# Start Home Assistant
+hass --config "${PWD}/config" --debug

--- a/scripts/lint
+++ b/scripts/lint
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+ruff format .
+ruff check . --fix

--- a/scripts/setup
+++ b/scripts/setup
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+python3 -m pip install --requirement requirements.txt


### PR DESCRIPTION
- Store configuration data in ConfigEntry instead of `hass.data`
- Rename some variables to better reflect contents
- Use _unique_ unique IDs

Devices may need to be deleted and added again after upgrade.