### PR TITLE
Use UTC for token_expire (sensor still local time)

### DIFF
--- a/custom_components/polestar_api/sensor.py
+++ b/custom_components/polestar_api/sensor.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Final
 
+import homeassistant.util.dt as dt
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -581,9 +582,8 @@ class PolestarSensor(PolestarEntity, SensorEntity):
             )
 
         if self.entity_description.key == "api_token_expires_at":
-            if self.car.get_token_expiry() is None:
-                return None
-            return self.car.get_token_expiry().strftime("%Y-%m-%d %H:%M:%S")
+            expire = self.car.get_token_expiry()
+            return dt.as_local(expire).strftime("%Y-%m-%d %H:%M:%S") if expire else None
         if self._attr_native_value != 0 and self._attr_native_value in (None, False):
             return None
 

--- a/custom_components/polestar_api/sensor.py
+++ b/custom_components/polestar_api/sensor.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Final
 
-import homeassistant.util.dt as dt
+import homeassistant.util.dt as dt_util
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -583,7 +583,11 @@ class PolestarSensor(PolestarEntity, SensorEntity):
 
         if self.entity_description.key == "api_token_expires_at":
             expire = self.car.get_token_expiry()
-            return dt.as_local(expire).strftime("%Y-%m-%d %H:%M:%S") if expire else None
+            return (
+                dt_util.as_local(expire).strftime("%Y-%m-%d %H:%M:%S")
+                if expire
+                else None
+            )
         if self._attr_native_value != 0 and self._attr_native_value in (None, False):
             return None
 


### PR DESCRIPTION
The current sensor for "API Token Expires At" shows time in UTC which is quite confusing for most users. This PR fixes this and displays the sensor in local time, but keeps the internal value in UTC.