### PR TITLE
Remove data caching

### DIFF
--- a/custom_components/polestar_api/const.py
+++ b/custom_components/polestar_api/const.py
@@ -6,7 +6,6 @@ from typing import Final
 DOMAIN = "polestar_api"
 TIMEOUT = 90
 
-CACHE_TIME = 600
 DEFAULT_SCAN_INTERVAL = timedelta(seconds=60)
 
 CONF_VIN: Final[str] = "vin"

--- a/custom_components/polestar_api/image.py
+++ b/custom_components/polestar_api/image.py
@@ -86,7 +86,6 @@ class PolestarImage(PolestarEntity, ImageEntity):
         value = self.car.get_value(
             query=self.entity_description.query,
             field_name=self.entity_description.field_name,
-            skip_cache=True,
         )
         if value is None:
             _LOGGER.debug("No image URL found")

--- a/custom_components/polestar_api/polestar.py
+++ b/custom_components/polestar_api/polestar.py
@@ -53,12 +53,6 @@ class PolestarCar:
             serial_number=self.vin,
         )
 
-    def get_latest_data(self, query: str, field_name: str):
-        """Get the latest data from the Polestar API."""
-        return self.polestar_api.get_latest_data(
-            vin=self.vin, query=query, field_name=field_name
-        )
-
     async def async_update(self) -> None:
         """Update data from Polestar."""
         try:
@@ -85,10 +79,12 @@ class PolestarCar:
             self.polestar_api.next_update = datetime.now() + timedelta(seconds=60)
         self.polestar_api.latest_call_code_v2 = 500
 
-    def get_value(self, query: str, field_name: str, skip_cache: bool = False):
+    def get_value(self, query: str, field_name: str):
         """Get the latest value from the Polestar API."""
-        data = self.polestar_api.get_cache_data(
-            vin=self.vin, query=query, field_name=field_name, skip_cache=skip_cache
+        if query is None or field_name is None:
+            return None
+        data = self.polestar_api.get_latest_data(
+            vin=self.vin, query=query, field_name=field_name
         )
         if data is None:
             # if amp and voltage can be null, so we will return 0

--- a/custom_components/polestar_api/pypolestar/const.py
+++ b/custom_components/polestar_api/pypolestar/const.py
@@ -1,7 +1,5 @@
 """Constants for Polestar."""
 
-CACHE_TIME = 30
-
 CAR_INFO_DATA = "getConsumerCarsV2"
 ODO_METER_DATA = "getOdometerData"
 BATTERY_DATA = "getBatteryData"

--- a/custom_components/polestar_api/pypolestar/polestar.py
+++ b/custom_components/polestar_api/pypolestar/polestar.py
@@ -203,10 +203,12 @@ class PolestarApi:
             variable_values={"vin": vin},
         )
 
-        self.cache_data_by_vin[vin][ODO_METER_DATA] = {
+        res = self.cache_data_by_vin[vin][ODO_METER_DATA] = {
             "data": result[ODO_METER_DATA],
             "timestamp": datetime.now(),
         }
+
+        self.logger.debug("Received odometer data: %s", res)
 
     async def _get_battery_data(self, vin: str) -> None:
         result = await self._query_graph_ql(
@@ -215,10 +217,12 @@ class PolestarApi:
             variable_values={"vin": vin},
         )
 
-        self.cache_data_by_vin[vin][BATTERY_DATA] = {
+        res = self.cache_data_by_vin[vin][BATTERY_DATA] = {
             "data": result[BATTERY_DATA],
             "timestamp": datetime.now(),
         }
+
+        self.logger.debug("Received battery data: %s", res)
 
     async def _get_vehicle_data(self, verbose: bool = False) -> dict | None:
         """Get the latest vehicle data from the Polestar API."""

--- a/custom_components/polestar_api/sensor.py
+++ b/custom_components/polestar_api/sensor.py
@@ -519,7 +519,6 @@ class PolestarSensor(PolestarEntity, SensorEntity):
         self._attr_native_value = self.car.get_value(
             self.entity_description.query,
             self.entity_description.field_name,
-            self.get_skip_cache(),
         )
 
         if entity_description.round_digits is not None:
@@ -532,21 +531,12 @@ class PolestarSensor(PolestarEntity, SensorEntity):
         if self.car is not None and self.car.get_latest_call_code() == 200:
             self._async_update_attrs()
 
-    def get_skip_cache(self) -> bool:
-        """Get the skip cache."""
-        return self.entity_description.key in (
-            "vin",
-            "registration_number",
-            "model_name",
-        )
-
     @callback
     def _async_update_attrs(self) -> None:
         """Update the state and attributes."""
         self._sensor_data = self.car.get_value(
             self.entity_description.query,
             self.entity_description.field_name,
-            self.get_skip_cache(),
         )
 
     @property
@@ -592,10 +582,10 @@ class PolestarSensor(PolestarEntity, SensorEntity):
             return None
 
         if self.entity_description.key in ("estimate_full_charge_range"):
-            battery_level = self.car.get_latest_data(
+            battery_level = self.car.get_value(
                 self.entity_description.query, "batteryChargeLevelPercentage"
             )
-            estimate_range = self.car.get_latest_data(
+            estimate_range = self.car.get_value(
                 self.entity_description.query, self.entity_description.field_name
             )
 
@@ -730,7 +720,6 @@ class PolestarSensor(PolestarEntity, SensorEntity):
             value = self.car.get_value(
                 self.entity_description.query,
                 self.entity_description.field_name,
-                self.get_skip_cache(),
             )
 
             if value is not None:


### PR DESCRIPTION
Given that we now thottle all calls to Polestar API, we no longer need our own caching and can simplify the code. Later on we can adjust the update frequency, e.g., make frequent queries for SoC during charging. For now we can settle for once a minute for all sensors.

Static car information (e.g., model) is still only fetched at startup only.

This is now stable for me, but needs more testing.