### PR TITLE
Add dataclass models

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,6 @@ lint:
 reformat:
 	ruff check --select I --fix $(SOURCE)
 	ruff format $(SOURCE)
+
+test:
+	PYTHONPATH=custom_components pytest -vv

--- a/custom_components/polestar_api/pypolestar/models.py
+++ b/custom_components/polestar_api/pypolestar/models.py
@@ -3,7 +3,14 @@ from datetime import date, datetime
 from enum import StrEnum
 from typing import Self
 
-from .utils import get_field_name_date, get_field_name_datetime, get_field_name_str
+from .utils import (
+    GqlDict,
+    get_field_name_date,
+    get_field_name_datetime,
+    get_field_name_float,
+    get_field_name_int,
+    get_field_name_str,
+)
 
 
 class ChargingConnectionStatus(StrEnum):
@@ -27,8 +34,8 @@ class ChargingStatus(StrEnum):
 
 @dataclass(frozen=True)
 class CarInformation:
-    vin: str
-    internal_vehicle_identifier: str
+    vin: str | None
+    internal_vehicle_identifier: str | None
     registration_no: str | None
     registration_date: date | None
     factory_complete_date: date | None
@@ -38,11 +45,13 @@ class CarInformation:
     software_version: str | None
 
     @classmethod
-    def from_dict(cls, data) -> Self:
+    def from_dict(cls, data: GqlDict) -> Self:
         return cls(
-            vin=data["vin"],
-            internal_vehicle_identifier=data["internalVehicleIdentifier"],
-            registration_no=data.get("registrationNo"),
+            vin=get_field_name_str("vin", data),
+            internal_vehicle_identifier=get_field_name_str(
+                "internalVehicleIdentifier", data
+            ),
+            registration_no=get_field_name_str("registrationNo", data),
             registration_date=get_field_name_date("registrationDate", data),
             factory_complete_date=get_field_name_date("factoryCompleteDate", data),
             image_url=get_field_name_str("content/images/studio/url", data),
@@ -61,12 +70,14 @@ class CarOdometerData:
     event_update_timestamp: datetime | None
 
     @classmethod
-    def from_dict(cls, data) -> Self:
+    def from_dict(cls, data: GqlDict) -> Self:
         return cls(
-            average_speed_km_per_hour=int(data["averageSpeedKmPerHour"]),
-            odometer_meters=int(data["odometerMeters"]),
-            trip_meter_automatic_km=int(data["tripMeterAutomaticKm"]),
-            trip_meter_manual_km=int(data["tripMeterManualKm"]),
+            average_speed_km_per_hour=get_field_name_float(
+                "averageSpeedKmPerHour", data
+            ),
+            odometer_meters=get_field_name_int("odometerMeters", data),
+            trip_meter_automatic_km=get_field_name_int("tripMeterAutomaticKm", data),
+            trip_meter_manual_km=get_field_name_int("tripMeterManualKm", data),
             event_update_timestamp=get_field_name_datetime(
                 "eventUpdatedTimestamp/iso", data
             ),
@@ -75,37 +86,43 @@ class CarOdometerData:
 
 @dataclass(frozen=True)
 class CarBatteryData:
-    average_energy_consumption_kwh_per_100km: float
-    battery_charge_level_percentage: int
+    average_energy_consumption_kwh_per_100km: float | None
+    battery_charge_level_percentage: int | None
     charger_connection_status: ChargingConnectionStatus
     charging_current_amps: int | None
     charging_power_watts: int | None
     charging_status: ChargingStatus
-    estimated_charging_time_minutes_to_target_distance: int
-    estimated_charging_time_to_full_minutes: int
-    estimated_distance_to_empty_km: int
+    estimated_charging_time_minutes_to_target_distance: int | None
+    estimated_charging_time_to_full_minutes: int | None
+    estimated_distance_to_empty_km: int | None
     event_update_timestamp: datetime | None
 
     @classmethod
-    def from_dict(cls, data) -> Self:
+    def from_dict(cls, data: GqlDict) -> Self:
         return cls(
-            average_energy_consumption_kwh_per_100km=data[
-                "averageEnergyConsumptionKwhPer100Km"
-            ],
-            battery_charge_level_percentage=data["batteryChargeLevelPercentage"],
+            average_energy_consumption_kwh_per_100km=get_field_name_float(
+                "averageEnergyConsumptionKwhPer100Km", data
+            ),
+            battery_charge_level_percentage=get_field_name_int(
+                "batteryChargeLevelPercentage", data
+            ),
             charger_connection_status=ChargingConnectionStatus[
-                data["chargerConnectionStatus"]
+                str(get_field_name_str("chargerConnectionStatus", data))
             ],
-            charging_current_amps=data.get("chargingCurrentAmps"),
-            charging_power_watts=data.get("chargingPowerWatts"),
-            charging_status=ChargingStatus[data["chargingStatus"]],
-            estimated_charging_time_minutes_to_target_distance=data[
-                "estimatedChargingTimeMinutesToTargetDistance"
+            charging_current_amps=get_field_name_int("chargingCurrentAmps", data),
+            charging_power_watts=get_field_name_int("chargingPowerWatts", data),
+            charging_status=ChargingStatus[
+                str(get_field_name_str("chargingStatus", data))
             ],
-            estimated_charging_time_to_full_minutes=data[
-                "estimatedChargingTimeToFullMinutes"
-            ],
-            estimated_distance_to_empty_km=data["estimatedDistanceToEmptyKm"],
+            estimated_charging_time_minutes_to_target_distance=get_field_name_int(
+                "estimatedChargingTimeMinutesToTargetDistance", data
+            ),
+            estimated_charging_time_to_full_minutes=get_field_name_int(
+                "estimatedChargingTimeToFullMinutes", data
+            ),
+            estimated_distance_to_empty_km=get_field_name_int(
+                "estimatedDistanceToEmptyKm", data
+            ),
             event_update_timestamp=get_field_name_datetime(
                 "eventUpdatedTimestamp/iso", data
             ),

--- a/custom_components/polestar_api/pypolestar/models.py
+++ b/custom_components/polestar_api/pypolestar/models.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from enum import StrEnum
 from typing import Self
 
@@ -33,7 +33,12 @@ class ChargingStatus(StrEnum):
 
 
 @dataclass(frozen=True)
-class CarInformation:
+class CarBaseInformation:
+    _received_timestamp: datetime
+
+
+@dataclass(frozen=True)
+class CarInformation(CarBaseInformation):
     vin: str | None
     internal_vehicle_identifier: str | None
     registration_no: str | None
@@ -58,15 +63,16 @@ class CarInformation:
             battery=get_field_name_str("content/specification/battery", data),
             torque=get_field_name_str("content/specification/torque", data),
             software_version=get_field_name_str("software/version", data),
+            _received_timestamp=datetime.now(tz=timezone.utc),
         )
 
 
 @dataclass(frozen=True)
-class CarOdometerData:
+class CarOdometerData(CarBaseInformation):
     average_speed_km_per_hour: float | None
     odometer_meters: int | None
-    trip_meter_automatic_km: int | None
-    trip_meter_manual_km: int | None
+    trip_meter_automatic_km: float | None
+    trip_meter_manual_km: float | None
     event_update_timestamp: datetime | None
 
     @classmethod
@@ -76,16 +82,17 @@ class CarOdometerData:
                 "averageSpeedKmPerHour", data
             ),
             odometer_meters=get_field_name_int("odometerMeters", data),
-            trip_meter_automatic_km=get_field_name_int("tripMeterAutomaticKm", data),
-            trip_meter_manual_km=get_field_name_int("tripMeterManualKm", data),
+            trip_meter_automatic_km=get_field_name_float("tripMeterAutomaticKm", data),
+            trip_meter_manual_km=get_field_name_float("tripMeterManualKm", data),
             event_update_timestamp=get_field_name_datetime(
                 "eventUpdatedTimestamp/iso", data
             ),
+            _received_timestamp=datetime.now(tz=timezone.utc),
         )
 
 
 @dataclass(frozen=True)
-class CarBatteryData:
+class CarBatteryData(CarBaseInformation):
     average_energy_consumption_kwh_per_100km: float | None
     battery_charge_level_percentage: int | None
     charger_connection_status: ChargingConnectionStatus
@@ -126,4 +133,5 @@ class CarBatteryData:
             event_update_timestamp=get_field_name_datetime(
                 "eventUpdatedTimestamp/iso", data
             ),
+            _received_timestamp=datetime.now(tz=timezone.utc),
         )

--- a/custom_components/polestar_api/pypolestar/models.py
+++ b/custom_components/polestar_api/pypolestar/models.py
@@ -1,0 +1,112 @@
+from dataclasses import dataclass
+from datetime import date, datetime
+from enum import StrEnum
+from typing import Self
+
+from .utils import get_field_name_date, get_field_name_datetime, get_field_name_str
+
+
+class ChargingConnectionStatus(StrEnum):
+    CHARGER_CONNECTION_STATUS_CONNECTED = "Connected"
+    CHARGER_CONNECTION_STATUS_DISCONNECTED = "Disconnected"
+    CHARGER_CONNECTION_STATUS_FAULT = "Fault"
+    CHARGER_CONNECTION_STATUS_UNSPECIFIED = "Unspecified"
+
+
+class ChargingStatus(StrEnum):
+    CHARGING_STATUS_DONE = "Done"
+    CHARGING_STATUS_IDLE = "Idle"
+    CHARGING_STATUS_CHARGING = "Charging"
+    CHARGING_STATUS_FAULT = "Fault"
+    CHARGING_STATUS_UNSPECIFIED = "Unspecified"
+    CHARGING_STATUS_SCHEDULED = "Scheduled"
+    CHARGING_STATUS_DISCHARGING = "Discharging"
+    CHARGING_STATUS_ERROR = "Error"
+    CHARGING_STATUS_SMART_CHARGING = "Smart Charging"
+
+
+@dataclass(frozen=True)
+class CarInformation:
+    vin: str
+    internal_vehicle_identifier: str
+    registration_no: str | None
+    registration_date: date | None
+    factory_complete_date: date | None
+    image_url: str | None
+    battery: str | None
+    torque: str | None
+    software_version: str | None
+
+    @classmethod
+    def from_dict(cls, data) -> Self:
+        return cls(
+            vin=data["vin"],
+            internal_vehicle_identifier=data["internalVehicleIdentifier"],
+            registration_no=data.get("registrationNo"),
+            registration_date=get_field_name_date("registrationDate", data),
+            factory_complete_date=get_field_name_date("factoryCompleteDate", data),
+            image_url=get_field_name_str("content/images/studio/url", data),
+            battery=get_field_name_str("content/specification/battery", data),
+            torque=get_field_name_str("content/specification/torque", data),
+            software_version=get_field_name_str("software/version", data),
+        )
+
+
+@dataclass(frozen=True)
+class CarOdometerData:
+    average_speed_km_per_hour: float | None
+    odometer_meters: int | None
+    trip_meter_automatic_km: int | None
+    trip_meter_manual_km: int | None
+    event_update_timestamp: datetime | None
+
+    @classmethod
+    def from_dict(cls, data) -> Self:
+        return cls(
+            average_speed_km_per_hour=int(data["averageSpeedKmPerHour"]),
+            odometer_meters=int(data["odometerMeters"]),
+            trip_meter_automatic_km=int(data["tripMeterAutomaticKm"]),
+            trip_meter_manual_km=int(data["tripMeterManualKm"]),
+            event_update_timestamp=get_field_name_datetime(
+                "eventUpdatedTimestamp/iso", data
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class CarBatteryData:
+    average_energy_consumption_kwh_per_100km: float
+    battery_charge_level_percentage: int
+    charger_connection_status: ChargingConnectionStatus
+    charging_current_amps: int | None
+    charging_power_watts: int | None
+    charging_status: ChargingStatus
+    estimated_charging_time_minutes_to_target_distance: int
+    estimated_charging_time_to_full_minutes: int
+    estimated_distance_to_empty_km: int
+    event_update_timestamp: datetime | None
+
+    @classmethod
+    def from_dict(cls, data) -> Self:
+        return cls(
+            average_energy_consumption_kwh_per_100km=data[
+                "averageEnergyConsumptionKwhPer100Km"
+            ],
+            battery_charge_level_percentage=data["batteryChargeLevelPercentage"],
+            charger_connection_status=ChargingConnectionStatus[
+                data["chargerConnectionStatus"]
+            ],
+            charging_current_amps=data.get("chargingCurrentAmps"),
+            charging_power_watts=data.get("chargingPowerWatts"),
+            charging_status=ChargingStatus[data["chargingStatus"]],
+            estimated_charging_time_minutes_to_target_distance=data[
+                "estimatedChargingTimeMinutesToTargetDistance"
+            ],
+            estimated_charging_time_to_full_minutes=data[
+                "estimatedChargingTimeToFullMinutes"
+            ],
+            estimated_distance_to_empty_km=data["estimatedDistanceToEmptyKm"],
+            event_update_timestamp=get_field_name_datetime(
+                "eventUpdatedTimestamp/iso", data
+            ),
+        )

--- a/custom_components/polestar_api/pypolestar/models.py
+++ b/custom_components/polestar_api/pypolestar/models.py
@@ -73,7 +73,7 @@ class CarOdometerData(CarBaseInformation):
     odometer_meters: int | None
     trip_meter_automatic_km: float | None
     trip_meter_manual_km: float | None
-    event_update_timestamp: datetime | None
+    event_updated_timestamp: datetime | None
 
     @classmethod
     def from_dict(cls, data: GqlDict) -> Self:
@@ -84,7 +84,7 @@ class CarOdometerData(CarBaseInformation):
             odometer_meters=get_field_name_int("odometerMeters", data),
             trip_meter_automatic_km=get_field_name_float("tripMeterAutomaticKm", data),
             trip_meter_manual_km=get_field_name_float("tripMeterManualKm", data),
-            event_update_timestamp=get_field_name_datetime(
+            event_updated_timestamp=get_field_name_datetime(
                 "eventUpdatedTimestamp/iso", data
             ),
             _received_timestamp=datetime.now(tz=timezone.utc),
@@ -102,7 +102,7 @@ class CarBatteryData(CarBaseInformation):
     estimated_charging_time_minutes_to_target_distance: int | None
     estimated_charging_time_to_full_minutes: int | None
     estimated_distance_to_empty_km: int | None
-    event_update_timestamp: datetime | None
+    event_updated_timestamp: datetime | None
 
     @classmethod
     def from_dict(cls, data: GqlDict) -> Self:
@@ -130,7 +130,7 @@ class CarBatteryData(CarBaseInformation):
             estimated_distance_to_empty_km=get_field_name_int(
                 "estimatedDistanceToEmptyKm", data
             ),
-            event_update_timestamp=get_field_name_datetime(
+            event_updated_timestamp=get_field_name_datetime(
                 "eventUpdatedTimestamp/iso", data
             ),
             _received_timestamp=datetime.now(tz=timezone.utc),

--- a/custom_components/polestar_api/pypolestar/models.py
+++ b/custom_components/polestar_api/pypolestar/models.py
@@ -106,6 +106,20 @@ class CarBatteryData(CarBaseInformation):
 
     @classmethod
     def from_dict(cls, data: GqlDict) -> Self:
+        try:
+            charger_connection_status = ChargingConnectionStatus(
+                get_field_name_str("chargerConnectionStatus", data)
+            )
+        except ValueError:
+            charger_connection_status = (
+                ChargingConnectionStatus.CHARGER_CONNECTION_STATUS_UNSPECIFIED
+            )
+
+        try:
+            charging_status = ChargingStatus(get_field_name_str("chargingStatus", data))
+        except ValueError:
+            charging_status = ChargingStatus.CHARGING_STATUS_UNSPECIFIED
+
         return cls(
             average_energy_consumption_kwh_per_100km=get_field_name_float(
                 "averageEnergyConsumptionKwhPer100Km", data
@@ -113,14 +127,10 @@ class CarBatteryData(CarBaseInformation):
             battery_charge_level_percentage=get_field_name_int(
                 "batteryChargeLevelPercentage", data
             ),
-            charger_connection_status=ChargingConnectionStatus[
-                str(get_field_name_str("chargerConnectionStatus", data))
-            ],
+            charger_connection_status=charger_connection_status,
             charging_current_amps=get_field_name_int("chargingCurrentAmps", data) or 0,
             charging_power_watts=get_field_name_int("chargingPowerWatts", data) or 0,
-            charging_status=ChargingStatus[
-                str(get_field_name_str("chargingStatus", data))
-            ],
+            charging_status=charging_status,
             estimated_charging_time_minutes_to_target_distance=get_field_name_int(
                 "estimatedChargingTimeMinutesToTargetDistance", data
             ),

--- a/custom_components/polestar_api/pypolestar/models.py
+++ b/custom_components/polestar_api/pypolestar/models.py
@@ -38,7 +38,7 @@ class CarBaseInformation:
 
 
 @dataclass(frozen=True)
-class CarInformation(CarBaseInformation):
+class CarInformationData(CarBaseInformation):
     vin: str | None
     internal_vehicle_identifier: str | None
     registration_no: str | None

--- a/custom_components/polestar_api/pypolestar/models.py
+++ b/custom_components/polestar_api/pypolestar/models.py
@@ -96,8 +96,8 @@ class CarBatteryData(CarBaseInformation):
     average_energy_consumption_kwh_per_100km: float | None
     battery_charge_level_percentage: int | None
     charger_connection_status: ChargingConnectionStatus
-    charging_current_amps: int | None
-    charging_power_watts: int | None
+    charging_current_amps: int
+    charging_power_watts: int
     charging_status: ChargingStatus
     estimated_charging_time_minutes_to_target_distance: int | None
     estimated_charging_time_to_full_minutes: int | None
@@ -116,8 +116,8 @@ class CarBatteryData(CarBaseInformation):
             charger_connection_status=ChargingConnectionStatus[
                 str(get_field_name_str("chargerConnectionStatus", data))
             ],
-            charging_current_amps=get_field_name_int("chargingCurrentAmps", data),
-            charging_power_watts=get_field_name_int("chargingPowerWatts", data),
+            charging_current_amps=get_field_name_int("chargingCurrentAmps", data) or 0,
+            charging_power_watts=get_field_name_int("chargingPowerWatts", data) or 0,
             charging_status=ChargingStatus[
                 str(get_field_name_str("chargingStatus", data))
             ],

--- a/custom_components/polestar_api/pypolestar/polestar.py
+++ b/custom_components/polestar_api/pypolestar/polestar.py
@@ -86,16 +86,64 @@ class PolestarApi:
         return list(self.data_by_vin.keys())
 
     def get_car_information(self, vin: str) -> CarInformationData | None:
+        """
+        Get car information for the specified VIN.
+
+        Args:
+            vin: The vehicle identification number
+        Returns:
+            CarInformationData if data exists, None otherwise
+        Raises:
+            KeyError: If the VIN doesn't exist
+            ValueError: If data conversion fails
+        """
+        if vin not in self.data_by_vin:
+            raise KeyError(f"No data found for VIN: {vin}")
         if data := self.data_by_vin[vin].get(CAR_INFO_DATA, {}).get("data"):
-            return CarInformationData.from_dict(data)
+            try:
+                return CarInformationData.from_dict(data)
+            except Exception as exc:
+                raise ValueError("Failed to convert car information data") from exc
 
     def get_car_battery(self, vin: str) -> CarBatteryData | None:
+        """
+        Get car battery information for the specified VIN.
+
+        Args:
+            vin: The vehicle identification number
+        Returns:
+            CarInformatiCarBatteryDataonData if data exists, None otherwise
+        Raises:
+            KeyError: If the VIN doesn't exist
+            ValueError: If data conversion fails
+        """
+        if vin not in self.data_by_vin:
+            raise KeyError(f"No data found for VIN: {vin}")
         if data := self.data_by_vin[vin].get(BATTERY_DATA, {}).get("data"):
-            return CarBatteryData.from_dict(data)
+            try:
+                return CarBatteryData.from_dict(data)
+            except Exception as exc:
+                raise ValueError("Failed to convert car battery data") from exc
 
     def get_car_odometer(self, vin: str) -> CarOdometerData | None:
+        """
+        Get car odomoter information for the specified VIN.
+
+        Args:
+            vin: The vehicle identification number
+        Returns:
+            CarOdometerData if data exists, None otherwise
+        Raises:
+            KeyError: If the VIN doesn't exist
+            ValueError: If data conversion fails
+        """
+        if vin not in self.data_by_vin:
+            raise KeyError(f"No data found for VIN: {vin}")
         if data := self.data_by_vin[vin].get(ODO_METER_DATA, {}).get("data"):
-            return CarOdometerData.from_dict(data)
+            try:
+                return CarOdometerData.from_dict(data)
+            except Exception as exc:
+                raise ValueError("Failed to convert car odometer data") from exc
 
     def get_latest_data(self, vin: str, query: str, field_name: str) -> dict | None:
         """Get the latest data from the Polestar API."""

--- a/custom_components/polestar_api/pypolestar/polestar.py
+++ b/custom_components/polestar_api/pypolestar/polestar.py
@@ -25,6 +25,7 @@ from .graphql import (
     QUERY_GET_ODOMETER_DATA,
     get_gql_client,
 )
+from .models import CarBatteryData, CarInformationData, CarOdometerData
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -83,6 +84,18 @@ class PolestarApi:
     @property
     def vins(self) -> list[str]:
         return list(self.data_by_vin.keys())
+
+    def get_car_information(self, vin: str) -> CarInformationData | None:
+        if data := self.data_by_vin[vin].get(CAR_INFO_DATA, {}).get("data"):
+            return CarInformationData.from_dict(data)
+
+    def get_car_battery(self, vin: str) -> CarBatteryData | None:
+        if data := self.data_by_vin[vin].get(BATTERY_DATA, {}).get("data"):
+            return CarBatteryData.from_dict(data)
+
+    def get_car_odometer(self, vin: str) -> CarOdometerData | None:
+        if data := self.data_by_vin[vin].get(ODO_METER_DATA, {}).get("data"):
+            return CarOdometerData.from_dict(data)
 
     def get_latest_data(self, vin: str, query: str, field_name: str) -> dict | None:
         """Get the latest data from the Polestar API."""

--- a/custom_components/polestar_api/pypolestar/utils.py
+++ b/custom_components/polestar_api/pypolestar/utils.py
@@ -96,11 +96,16 @@ def get_field_name_date(field_name: str, data: GqlDict) -> date | None:
     Returns:
         date object if conversion successful, None otherwise
     """
-    if (value := get_field_name_value(field_name, data)) and isinstance(value, str):
-        try:
-            return date.fromisoformat(value)
-        except ValueError as exc:
-            raise ValueError(f"Invalid date format at '{field_name}': {value}") from exc
+    if value := get_field_name_value(field_name, data):
+        if isinstance(value, date):
+            return value
+        if isinstance(value, str):
+            try:
+                return date.fromisoformat(value)
+            except ValueError as exc:
+                raise ValueError(
+                    f"Invalid date format at '{field_name}': {value}"
+                ) from exc
 
 
 def get_field_name_datetime(field_name: str, data: GqlDict) -> datetime | None:
@@ -111,10 +116,13 @@ def get_field_name_datetime(field_name: str, data: GqlDict) -> datetime | None:
     Returns:
         datetime object if conversion successful, None otherwise
     """
-    if (value := get_field_name_value(field_name, data)) and isinstance(value, str):
-        try:
-            return datetime.fromisoformat(value)
-        except ValueError as exc:
-            raise ValueError(
-                f"Invalid datetime format at '{field_name}': {value}"
-            ) from exc
+    if value := get_field_name_value(field_name, data):
+        if isinstance(value, datetime):
+            return value
+        if isinstance(value, str):
+            try:
+                return datetime.fromisoformat(value)
+            except ValueError as exc:
+                raise ValueError(
+                    f"Invalid datetime format at '{field_name}': {value}"
+                ) from exc

--- a/custom_components/polestar_api/pypolestar/utils.py
+++ b/custom_components/polestar_api/pypolestar/utils.py
@@ -1,0 +1,42 @@
+from datetime import date, datetime
+
+GqlScalar = int | float | str | bool | None
+
+GqlDict = dict[str, type["GqlDict"] | GqlScalar]
+
+
+def get_field_name_value(field_name: str, data: GqlDict) -> GqlScalar | GqlDict:
+    if field_name is None or data is None:
+        return None
+
+    result: GqlScalar | GqlDict = data
+    valid = False
+
+    for key in field_name.split("/"):
+        if isinstance(result, dict):
+            if key not in result:
+                raise KeyError(field_name)
+            result = result[key]  # type: ignore
+            valid = True
+        else:
+            raise KeyError(field_name)
+
+    if valid:
+        return result
+
+    raise KeyError(field_name)
+
+
+def get_field_name_str(field_name: str, data: GqlDict) -> str | None:
+    if (value := get_field_name_value(field_name, data)) and isinstance(value, str):
+        return value
+
+
+def get_field_name_date(field_name: str, data: GqlDict) -> date | None:
+    if (value := get_field_name_value(field_name, data)) and isinstance(value, str):
+        return date.fromisoformat(value)
+
+
+def get_field_name_datetime(field_name: str, data: GqlDict) -> datetime | None:
+    if (value := get_field_name_value(field_name, data)) and isinstance(value, str):
+        return datetime.fromisoformat(value)

--- a/custom_components/polestar_api/pypolestar/utils.py
+++ b/custom_components/polestar_api/pypolestar/utils.py
@@ -32,6 +32,16 @@ def get_field_name_str(field_name: str, data: GqlDict) -> str | None:
         return value
 
 
+def get_field_name_float(field_name: str, data: GqlDict) -> float | None:
+    if (value := get_field_name_value(field_name, data)) and isinstance(value, float):
+        return value
+
+
+def get_field_name_int(field_name: str, data: GqlDict) -> int | None:
+    if (value := get_field_name_value(field_name, data)) and isinstance(value, int):
+        return value
+
+
 def get_field_name_date(field_name: str, data: GqlDict) -> date | None:
     if (value := get_field_name_value(field_name, data)) and isinstance(value, str):
         return date.fromisoformat(value)

--- a/custom_components/polestar_api/pypolestar/utils.py
+++ b/custom_components/polestar_api/pypolestar/utils.py
@@ -39,7 +39,7 @@ def get_field_name_value(field_name: str, data: GqlDict) -> GqlScalar | GqlDict:
 def get_field_name_str(field_name: str, data: GqlDict) -> str | None:
     """Extract a str value from the nested dictionary.
     Args:
-        field_name: Path to the date field
+        field_name: Path to the str field
         data: Nested dictionary containing the data
     Returns:
         str if successful, None otherwise
@@ -51,7 +51,7 @@ def get_field_name_str(field_name: str, data: GqlDict) -> str | None:
 def get_field_name_float(field_name: str, data: GqlDict) -> float | None:
     """Extract a float value from the nested dictionary.
     Args:
-        field_name: Path to the date field
+        field_name: Path to the float field
         data: Nested dictionary containing the data
     Returns:
         float if successful, None otherwise
@@ -63,7 +63,7 @@ def get_field_name_float(field_name: str, data: GqlDict) -> float | None:
 def get_field_name_int(field_name: str, data: GqlDict) -> int | None:
     """Extract a int value from the nested dictionary.
     Args:
-        field_name: Path to the date field
+        field_name: Path to the int field
         data: Nested dictionary containing the data
     Returns:
         int if successful, None otherwise

--- a/custom_components/polestar_api/pypolestar/utils.py
+++ b/custom_components/polestar_api/pypolestar/utils.py
@@ -79,6 +79,13 @@ def get_field_name_int(field_name: str, data: GqlDict) -> int | None:
     """
     if (value := get_field_name_value(field_name, data)) and isinstance(value, int):
         return value
+    elif value is not None:
+        try:
+            return int(value)
+        except (ValueError, TypeError) as exc:
+            raise ValueError(
+                f"Invalid integer value at '{field_name}': {value}"
+            ) from exc
 
 
 def get_field_name_date(field_name: str, data: GqlDict) -> date | None:

--- a/custom_components/polestar_api/pypolestar/utils.py
+++ b/custom_components/polestar_api/pypolestar/utils.py
@@ -2,7 +2,7 @@ from datetime import date, datetime
 
 GqlScalar = int | float | str | bool | None
 
-GqlDict = dict[str, type["GqlDict"] | GqlScalar]
+GqlDict = dict[str, "GqlDict" | GqlScalar]
 
 
 def get_field_name_value(field_name: str, data: GqlDict) -> GqlScalar | GqlDict:

--- a/custom_components/polestar_api/pypolestar/utils.py
+++ b/custom_components/polestar_api/pypolestar/utils.py
@@ -7,14 +7,14 @@ GqlDict = dict[str, type["GqlDict"] | GqlScalar]
 
 def get_field_name_value(field_name: str, data: GqlDict) -> GqlScalar | GqlDict:
     """Extract a value from nested dictionary using path-like notation.
-    
+
     Args:
         field_name: Path to the field using "/" as separator (e.g., "car/status/battery")
         data: Nested dictionary containing the data
-        
+
     Returns:
         The value at the specified path
-        
+
     Raises:
         KeyError: If the path doesn't exist or is invalid
     """
@@ -29,30 +29,78 @@ def get_field_name_value(field_name: str, data: GqlDict) -> GqlScalar | GqlDict:
                 raise KeyError(f"Key '{key}' not found in path '{field_name}'")
             result = result[key]
         else:
-            raise KeyError(f"Cannot access key '{key}' in non-dict value at path '{field_name}'")
+            raise KeyError(
+                f"Cannot access key '{key}' in non-dict value at path '{field_name}'"
+            )
 
     return result
 
+
 def get_field_name_str(field_name: str, data: GqlDict) -> str | None:
-    if (value := get_field_name_value(field_name, data)) and isinstance(value, str):
+    """Extract a str value from the nested dictionary.
+    Args:
+        field_name: Path to the date field
+        data: Nested dictionary containing the data
+    Returns:
+        str if successful, None otherwise
+    """
+    if (value := get_field_name_value(field_name, data)) and (isinstance(value, str)):
         return value
 
 
 def get_field_name_float(field_name: str, data: GqlDict) -> float | None:
+    """Extract a float value from the nested dictionary.
+    Args:
+        field_name: Path to the date field
+        data: Nested dictionary containing the data
+    Returns:
+        float if successful, None otherwise
+    """
     if (value := get_field_name_value(field_name, data)) and isinstance(value, float):
         return value
 
 
 def get_field_name_int(field_name: str, data: GqlDict) -> int | None:
+    """Extract a int value from the nested dictionary.
+    Args:
+        field_name: Path to the date field
+        data: Nested dictionary containing the data
+    Returns:
+        int if successful, None otherwise
+    """
     if (value := get_field_name_value(field_name, data)) and isinstance(value, int):
         return value
 
 
 def get_field_name_date(field_name: str, data: GqlDict) -> date | None:
+    """Extract and convert a date value from the nested dictionary.
+    Args:
+        field_name: Path to the date field
+        data: Nested dictionary containing the data
+    Returns:
+        date object if conversion successful, None otherwise
+    """
     if (value := get_field_name_value(field_name, data)) and isinstance(value, str):
-        return date.fromisoformat(value)
+        try:
+            return date.fromisoformat(value)
+        except ValueError as exc:
+            raise ValueError(
+                f"Invalid datetime format at '{field_name}': {value}"
+            ) from exc
 
 
 def get_field_name_datetime(field_name: str, data: GqlDict) -> datetime | None:
+    """Extract and convert a datetime value from the nested dictionary.
+    Args:
+        field_name: Path to the datetime field
+        data: Nested dictionary containing the data
+    Returns:
+        datetime object if conversion successful, None otherwise
+    """
     if (value := get_field_name_value(field_name, data)) and isinstance(value, str):
-        return datetime.fromisoformat(value)
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError as exc:
+            raise ValueError(
+                f"Invalid datetime format at '{field_name}': {value}"
+            ) from exc

--- a/custom_components/polestar_api/pypolestar/utils.py
+++ b/custom_components/polestar_api/pypolestar/utils.py
@@ -6,26 +6,32 @@ GqlDict = dict[str, type["GqlDict"] | GqlScalar]
 
 
 def get_field_name_value(field_name: str, data: GqlDict) -> GqlScalar | GqlDict:
+    """Extract a value from nested dictionary using path-like notation.
+    
+    Args:
+        field_name: Path to the field using "/" as separator (e.g., "car/status/battery")
+        data: Nested dictionary containing the data
+        
+    Returns:
+        The value at the specified path
+        
+    Raises:
+        KeyError: If the path doesn't exist or is invalid
+    """
     if field_name is None or data is None:
         return None
 
     result: GqlScalar | GqlDict = data
-    valid = False
 
     for key in field_name.split("/"):
         if isinstance(result, dict):
             if key not in result:
-                raise KeyError(field_name)
-            result = result[key]  # type: ignore
-            valid = True
+                raise KeyError(f"Key '{key}' not found in path '{field_name}'")
+            result = result[key]
         else:
-            raise KeyError(field_name)
+            raise KeyError(f"Cannot access key '{key}' in non-dict value at path '{field_name}'")
 
-    if valid:
-        return result
-
-    raise KeyError(field_name)
-
+    return result
 
 def get_field_name_str(field_name: str, data: GqlDict) -> str | None:
     if (value := get_field_name_value(field_name, data)) and isinstance(value, str):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ homeassistant==2024.6.0
 pip>=21.3.1
 ruff==0.7.1
 gql[httpx]>=3.5.0
+pytest>=8.3.3

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,61 @@
+from datetime import date, datetime
+
+import pytest
+from polestar_api.pypolestar.utils import (
+    get_field_name_date,
+    get_field_name_datetime,
+    get_field_name_str,
+    get_field_name_value,
+)
+
+TESTDATA = {
+    "vin": "YSMYKEAE7RB000000",
+    "internalVehicleIdentifier": "0c5f757e-5eb3-4191-b786-0513ddaa452f",
+    "registrationNo": "MLB007",
+    "registrationDate": None,
+    "factoryCompleteDate": "2024-04-16",
+    "content": {
+        "model": {"name": "Polestar 3"},
+        "images": {
+            "studio": {"url": "https://example.com/image.png"},
+            "specification": {
+                "battery": "400V lithium-ion battery, 111 kWh capacity, 17 modules",
+                "torque": "840 Nm / 620 lbf-ft",
+            },
+        },
+        "software": {"version": None, "versionTimestamp": None},
+    },
+}
+
+
+def test_get_field_name_value():
+    assert get_field_name_value("vin", TESTDATA) == "YSMYKEAE7RB000000"
+    assert get_field_name_value("content/model/name", TESTDATA) == "Polestar 3"
+    assert get_field_name_value("content/software/version", TESTDATA) is None
+    assert get_field_name_value("content/images/studio", TESTDATA) == {
+        "url": "https://example.com/image.png"
+    }
+    with pytest.raises(KeyError):
+        assert (
+            get_field_name_value("content/model/name/xyzzy", TESTDATA) == "Polestar 3"
+        )
+    with pytest.raises(KeyError):
+        get_field_name_value("xyzzy", TESTDATA)
+    with pytest.raises(KeyError):
+        get_field_name_value("content/xyzzy", TESTDATA)
+
+
+def test_get_field_name_str():
+    assert get_field_name_str("vin", TESTDATA) == "YSMYKEAE7RB000000"
+
+
+def test_get_field_name_date():
+    assert get_field_name_date("factoryCompleteDate", TESTDATA) == date(
+        year=2024, month=4, day=16
+    )
+
+
+def test_get_field_name_datetime():
+    assert get_field_name_datetime("factoryCompleteDate", TESTDATA) == datetime(
+        year=2024, month=4, day=16
+    )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -51,25 +51,34 @@ def test_get_field_name_value():
 
 def test_get_field_name_str():
     assert get_field_name_str("vin", TESTDATA) == "YSMYKEAE7RB000000"
+    assert get_field_name_str("registrationDate", TESTDATA) is None  # None handling
 
 
 def test_get_field_name_float():
     assert (
         get_field_name_float("averageEnergyConsumptionKwhPer100Km", TESTDATA) == 42.01
     )
+    assert get_field_name_float("registrationDate", TESTDATA) is None  # None handling
 
 
 def test_get_field_name_int():
     assert get_field_name_int("batteryChargeLevelPercentage", TESTDATA) == 100
+    assert get_field_name_int("registrationDate", TESTDATA) is None  # None handling
 
 
 def test_get_field_name_date():
-    assert get_field_name_date("factoryCompleteDate", TESTDATA) == date(
-        year=2024, month=4, day=16
-    )
+    assert get_field_name_date("factoryCompleteDate", TESTDATA) == date(2024, 4, 16)
+    assert get_field_name_date("registrationDate", TESTDATA) is None  # None handling
+    with pytest.raises(ValueError):  # Invalid date
+        get_field_name_date("vin", TESTDATA)
 
 
 def test_get_field_name_datetime():
     assert get_field_name_datetime("factoryCompleteDate", TESTDATA) == datetime(
-        year=2024, month=4, day=16
+        2024, 4, 16
     )
+    assert (
+        get_field_name_datetime("registrationDate", TESTDATA) is None
+    )  # None handling
+    with pytest.raises(ValueError):  # Invalid datetime
+        get_field_name_datetime("vin", TESTDATA)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,8 @@ import pytest
 from polestar_api.pypolestar.utils import (
     get_field_name_date,
     get_field_name_datetime,
+    get_field_name_float,
+    get_field_name_int,
     get_field_name_str,
     get_field_name_value,
 )
@@ -25,6 +27,8 @@ TESTDATA = {
         },
         "software": {"version": None, "versionTimestamp": None},
     },
+    "averageEnergyConsumptionKwhPer100Km": 42.01,
+    "batteryChargeLevelPercentage": 100,
 }
 
 
@@ -47,6 +51,16 @@ def test_get_field_name_value():
 
 def test_get_field_name_str():
     assert get_field_name_str("vin", TESTDATA) == "YSMYKEAE7RB000000"
+
+
+def test_get_field_name_float():
+    assert (
+        get_field_name_float("averageEnergyConsumptionKwhPer100Km", TESTDATA) == 42.01
+    )
+
+
+def test_get_field_name_int():
+    assert get_field_name_int("batteryChargeLevelPercentage", TESTDATA) == 100
 
 
 def test_get_field_name_date():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -59,6 +59,8 @@ def test_get_field_name_float():
         get_field_name_float("averageEnergyConsumptionKwhPer100Km", TESTDATA) == 42.01
     )
     assert get_field_name_float("registrationDate", TESTDATA) is None  # None handling
+    with pytest.raises(ValueError):  # Invalid date
+        get_field_name_float("vin", TESTDATA)
 
 
 def test_get_field_name_int():


### PR DESCRIPTION
The current API only provides access to the GraphQL queries and fields. This PR adds code for a more pythonic data model based on dataclasses, resulting in an API less tightly coupled with the backend GraphQL representation. A client of `pypolestar` should not need to know anything about GraphQL, fields etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced methods to retrieve car data based on VIN, including car information, battery status, and odometer readings.
  - Added a new target in the Makefile for running tests.

- **Enhancements**
  - New data classes for structured vehicle information, including car specifications, odometer data, and battery details.
  - Added utility functions for safely accessing and converting values from nested data structures.

- **Testing**
  - Implemented a comprehensive suite of unit tests for utility functions to ensure reliability and correctness.

- **Dependencies**
  - Updated requirements to include `pytest` for testing capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->