### PR TITLE
Add binary sensor for API connection

### DIFF
--- a/custom_components/polestar_api/__init__.py
+++ b/custom_components/polestar_api/__init__.py
@@ -12,7 +12,7 @@ from .data import PolestarConfigEntry, PolestarData
 from .polestar import PolestarCar, PolestarCoordinator
 from .pypolestar.exception import PolestarApiException, PolestarAuthException
 
-PLATFORMS = [Platform.IMAGE, Platform.SENSOR]
+PLATFORMS = [Platform.IMAGE, Platform.SENSOR, Platform.BINARY_SENSOR]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/polestar_api/binary_sensor.py
+++ b/custom_components/polestar_api/binary_sensor.py
@@ -1,0 +1,69 @@
+"""Support for Polestar binary sensors."""
+
+import logging
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN as POLESTAR_API_DOMAIN
+from .data import PolestarConfigEntry
+from .entity import PolestarEntity
+from .polestar import PolestarCar
+
+_LOGGER = logging.getLogger(__name__)
+
+
+ENTITY_DESCRIPTIONS = (
+    BinarySensorEntityDescription(
+        key="api_connected",
+        name="API Connected",
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,  # noqa: ARG001 Unused function argument: `hass`
+    entry: PolestarConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the binary_sensor platform."""
+    async_add_entities(
+        PolestarBinarySensor(
+            car=car,
+            entity_description=entity_description,
+        )
+        for entity_description in ENTITY_DESCRIPTIONS
+        for car in entry.runtime_data.cars
+    )
+
+
+class PolestarBinarySensor(PolestarEntity, BinarySensorEntity):
+    """integration_blueprint binary_sensor class."""
+
+    def __init__(
+        self,
+        car: PolestarCar,
+        entity_description: BinarySensorEntityDescription,
+    ) -> None:
+        """Initialize the binary_sensor class."""
+        super().__init__(car)
+        self.car = car
+        self.entity_description = entity_description
+        self.entity_id = f"{POLESTAR_API_DOMAIN}.'polestar_'.{car.get_short_id()}_{entity_description.key}"
+        self._attr_unique_id = (
+            f"polestar_{car.get_unique_id()}_{entity_description.key}"
+        )
+        self._attr_translation_key = f"polestar_{entity_description.key}"
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if the binary_sensor is on."""
+        return self.car.data.get(self.entity_description.key)

--- a/custom_components/polestar_api/polestar.py
+++ b/custom_components/polestar_api/polestar.py
@@ -34,6 +34,7 @@ class PolestarCar:
         )
         self.scan_interval = DEFAULT_SCAN_INTERVAL
         self.async_update = Throttle(min_time=self.scan_interval)(self.async_update)
+        self.data = {}
 
     def get_unique_id(self) -> str:
         """Return unique identifier"""
@@ -57,6 +58,11 @@ class PolestarCar:
         """Update data from Polestar."""
         try:
             await self.polestar_api.get_ev_data(self.vin)
+            self.data["api_connected"] = (
+                self.polestar_api.latest_call_code == 200
+                and self.polestar_api.auth.latest_call_code == 200
+                and self.polestar_api.auth.is_token_valid()
+            )
             return
         except PolestarApiException as e:
             _LOGGER.warning("API Exception on update data %s", str(e))

--- a/custom_components/polestar_api/pypolestar/auth.py
+++ b/custom_components/polestar_api/pypolestar/auth.py
@@ -65,6 +65,13 @@ class PolestarAuth:
             return True
         return False
 
+    def is_token_valid(self) -> bool:
+        return (
+            self.access_token is not None
+            and self.token_expiry is not None
+            and self.token_expiry > datetime.now(tz=timezone.utc)
+        )
+
     async def get_token(self, refresh=False) -> None:
         """Get the token from Polestar."""
         # can't use refresh if the token is expired or not set even if refresh is True


### PR DESCRIPTION
Add a binary sensor representing API connection. The sensor should be ON (connected) if both APIs return 200 and we have a valid access token.