### PR TITLE
Use Home Assistant 2024.12.0 and Python 3.13 in devcontainer

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "pypolestar/polestar_api",
-    "image": "mcr.microsoft.com/devcontainers/python:3.12",
+    "image": "mcr.microsoft.com/devcontainers/python:dev-3.13",
     "postCreateCommand": "scripts/setup",
     "forwardPorts": [
         8123

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 colorlog==6.8.2
-homeassistant==2024.6.0
+homeassistant==2024.12.0
 pip>=21.3.1
-ruff==0.7.1
+ruff==0.8.2
 gql[httpx]>=3.5.0
 pytest>=8.3.3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated development environment to use a newer Python Docker image.
  
- **Bug Fixes**
	- Upgraded `homeassistant` to version `2024.12.0` for improved functionality.
	- Updated `ruff` to version `0.8.2` for better performance and features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->