### PR TITLE
Remove handling of max value

### DIFF
--- a/custom_components/polestar_api/sensor.py
+++ b/custom_components/polestar_api/sensor.py
@@ -45,7 +45,6 @@ class PolestarSensorDescriptionMixin:
     """Define an entity description mixin for sensor entities."""
 
     round_digits: int | None
-    max_value: int | None
 
 
 @dataclass
@@ -73,7 +72,6 @@ POLESTAR_SENSOR_TYPES: Final[tuple[PolestarSensorDescription, ...]] = (
         round_digits=2,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.DISTANCE,
-        max_value=660,
     ),
     PolestarSensorDescription(
         key="current_odometer",
@@ -85,7 +83,6 @@ POLESTAR_SENSOR_TYPES: Final[tuple[PolestarSensorDescription, ...]] = (
         round_digits=2,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.DISTANCE,
-        max_value=1000000000,
     ),
     PolestarSensorDescription(
         key="average_speed",
@@ -95,7 +92,6 @@ POLESTAR_SENSOR_TYPES: Final[tuple[PolestarSensorDescription, ...]] = (
         round_digits=None,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.SPEED,
-        max_value=150,
     ),
     PolestarSensorDescription(
         key="current_trip_meter_automatic",
@@ -106,7 +102,6 @@ POLESTAR_SENSOR_TYPES: Final[tuple[PolestarSensorDescription, ...]] = (
         round_digits=2,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.DISTANCE,
-        max_value=100000,
     ),
     PolestarSensorDescription(
         key="current_trip_meter_manual",
@@ -117,7 +112,6 @@ POLESTAR_SENSOR_TYPES: Final[tuple[PolestarSensorDescription, ...]] = (
         round_digits=2,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.DISTANCE,
-        max_value=100000,
     ),
     PolestarSensorDescription(
         key="battery_charge_level",
@@ -126,7 +120,6 @@ POLESTAR_SENSOR_TYPES: Final[tuple[PolestarSensorDescription, ...]] = (
         round_digits=0,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.BATTERY,
-        max_value=100,
     ),
     PolestarSensorDescription(
         key="estimated_charging_time_to_full",
@@ -134,7 +127,6 @@ POLESTAR_SENSOR_TYPES: Final[tuple[PolestarSensorDescription, ...]] = (
         icon="mdi:battery-clock",
         native_unit_of_measurement=UnitOfTime.MINUTES,
         round_digits=None,
-        max_value=None,
     ),
     PolestarSensorDescription(
         key="charging_status",
@@ -142,7 +134,6 @@ POLESTAR_SENSOR_TYPES: Final[tuple[PolestarSensorDescription, ...]] = (
         icon="mdi:ev-station",
         native_unit_of_measurement=None,
         round_digits=None,
-        max_value=None,
     ),
     PolestarSensorDescription(
         key="charging_power",
@@ -151,7 +142,6 @@ POLESTAR_SENSOR_TYPES: Final[tuple[PolestarSensorDescription, ...]] = (
         native_unit_of_measurement=UnitOfPower.WATT,
         suggested_display_precision=0,
         round_digits=None,
-        max_value=None,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.POWER,
     ),
@@ -162,7 +152,6 @@ POLESTAR_SENSOR_TYPES: Final[tuple[PolestarSensorDescription, ...]] = (
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         suggested_display_precision=0,
         round_digits=None,
-        max_value=None,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.CURRENT,
     ),
@@ -172,7 +161,6 @@ POLESTAR_SENSOR_TYPES: Final[tuple[PolestarSensorDescription, ...]] = (
         icon="mdi:connection",
         native_unit_of_measurement=None,
         round_digits=None,
-        max_value=None,
         device_class=None,
     ),
     PolestarSensorDescription(
@@ -182,7 +170,6 @@ POLESTAR_SENSOR_TYPES: Final[tuple[PolestarSensorDescription, ...]] = (
         native_unit_of_measurement="kWh/100km",
         suggested_display_precision=1,
         round_digits=None,
-        max_value=None,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=None,
     ),
@@ -192,7 +179,6 @@ POLESTAR_SENSOR_TYPES: Final[tuple[PolestarSensorDescription, ...]] = (
         icon="mdi:battery-clock",
         native_unit_of_measurement=UnitOfTime.MINUTES,
         round_digits=None,
-        max_value=None,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=None,
     ),
@@ -202,7 +188,6 @@ POLESTAR_SENSOR_TYPES: Final[tuple[PolestarSensorDescription, ...]] = (
         icon="mdi:card-account-details",
         native_unit_of_measurement=None,
         round_digits=None,
-        max_value=None,
     ),
     PolestarSensorDescription(
         key="software_version",
@@ -210,7 +195,6 @@ POLESTAR_SENSOR_TYPES: Final[tuple[PolestarSensorDescription, ...]] = (
         icon="mdi:information-outline",
         native_unit_of_measurement=None,
         round_digits=None,
-        max_value=None,
     ),
     PolestarSensorDescription(
         key="software_version_release",
@@ -220,7 +204,6 @@ POLESTAR_SENSOR_TYPES: Final[tuple[PolestarSensorDescription, ...]] = (
         device_class=SensorDeviceClass.TIMESTAMP,
         native_unit_of_measurement=None,
         round_digits=None,
-        max_value=None,
     ),
     PolestarSensorDescription(
         key="registration_number",
@@ -228,7 +211,6 @@ POLESTAR_SENSOR_TYPES: Final[tuple[PolestarSensorDescription, ...]] = (
         icon="mdi:numeric-1-box",
         native_unit_of_measurement=None,
         round_digits=None,
-        max_value=None,
     ),
     PolestarSensorDescription(
         key="internal_vehicle_id",
@@ -236,7 +218,6 @@ POLESTAR_SENSOR_TYPES: Final[tuple[PolestarSensorDescription, ...]] = (
         icon="mdi:numeric-1-box",
         native_unit_of_measurement=None,
         round_digits=None,
-        max_value=None,
         entity_registry_enabled_default=False,
     ),
     PolestarSensorDescription(
@@ -247,7 +228,6 @@ POLESTAR_SENSOR_TYPES: Final[tuple[PolestarSensorDescription, ...]] = (
         round_digits=None,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.DURATION,
-        max_value=None,
     ),
     PolestarSensorDescription(
         key="model_name",
@@ -255,7 +235,6 @@ POLESTAR_SENSOR_TYPES: Final[tuple[PolestarSensorDescription, ...]] = (
         icon="mdi:car-electric",
         native_unit_of_measurement=None,
         round_digits=None,
-        max_value=None,
     ),
     PolestarSensorDescription(
         key="last_updated_odometer_data",
@@ -266,7 +245,6 @@ POLESTAR_SENSOR_TYPES: Final[tuple[PolestarSensorDescription, ...]] = (
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.TIMESTAMP,
         entity_category=EntityCategory.DIAGNOSTIC,
-        max_value=None,
     ),
     PolestarSensorDescription(
         key="last_updated_battery_data",
@@ -277,7 +255,6 @@ POLESTAR_SENSOR_TYPES: Final[tuple[PolestarSensorDescription, ...]] = (
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.TIMESTAMP,
         entity_category=EntityCategory.DIAGNOSTIC,
-        max_value=None,
     ),
     PolestarSensorDescription(
         key="estimate_full_charge_range",
@@ -288,7 +265,6 @@ POLESTAR_SENSOR_TYPES: Final[tuple[PolestarSensorDescription, ...]] = (
         round_digits=None,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.DISTANCE,
-        max_value=660,  # WLTP range max 655
     ),
     PolestarSensorDescription(
         key="api_status_code_data",
@@ -296,7 +272,6 @@ POLESTAR_SENSOR_TYPES: Final[tuple[PolestarSensorDescription, ...]] = (
         icon="mdi:heart",
         native_unit_of_measurement=None,
         round_digits=None,
-        max_value=None,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
@@ -306,7 +281,6 @@ POLESTAR_SENSOR_TYPES: Final[tuple[PolestarSensorDescription, ...]] = (
         icon="mdi:heart",
         native_unit_of_measurement=None,
         round_digits=None,
-        max_value=None,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
@@ -316,7 +290,6 @@ POLESTAR_SENSOR_TYPES: Final[tuple[PolestarSensorDescription, ...]] = (
         icon="mdi:clock-time-eight",
         native_unit_of_measurement=None,
         round_digits=None,
-        max_value=None,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
@@ -326,7 +299,6 @@ POLESTAR_SENSOR_TYPES: Final[tuple[PolestarSensorDescription, ...]] = (
         icon="mdi:card-account-details",
         native_unit_of_measurement="Nm",
         round_digits=None,
-        max_value=None,
     ),
     PolestarSensorDescription(
         key="battery_capacity",
@@ -335,7 +307,6 @@ POLESTAR_SENSOR_TYPES: Final[tuple[PolestarSensorDescription, ...]] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         suggested_display_precision=0,
         round_digits=None,
-        max_value=None,
         state_class=SensorStateClass.TOTAL,
         device_class=SensorDeviceClass.ENERGY,
     ),
@@ -479,30 +450,6 @@ class PolestarSensor(PolestarEntity, SensorEntity):
                     self._attr_native_unit_of_measurement = (
                         self._sensor_option_unit_of_measurement
                     )
-
-        if self.entity_description.key in (
-            "estimate_range",
-            "estimate_full_charge_range",
-        ):
-            if self._sensor_option_unit_of_measurement == UnitOfLength.MILES:
-                self.entity_description.max_value = 410
-            elif self._sensor_option_unit_of_measurement == UnitOfLength.KILOMETERS:
-                self.entity_description.max_value = 660
-            elif self._sensor_option_unit_of_measurement == UnitOfLength.METERS:
-                self.entity_description.max_value = 660000
-
-        # prevent exponentianal value, we only give state value that is lower than the max value
-        if self.entity_description.max_value is not None:
-            if isinstance(self._sensor_data, str):
-                self._attr_native_value = int(self._sensor_data)
-            if self._attr_native_value > self.entity_description.max_value:
-                _LOGGER.warning(
-                    "%s: Value %s is higher than max value %s",
-                    self.entity_description.key,
-                    self._attr_native_value,
-                    self.entity_description.max_value,
-                )
-                return None
 
         # only round value if native value is not None
         if self._attr_native_value:  # noqa


### PR DESCRIPTION
Remove handling of `max_value` from the sensor. If we should do this because the API returns bogus data, it should be done in the model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Removed maximum value constraints for various sensor types, allowing for greater flexibility in sensor readings.
  
- **Bug Fixes**
	- Eliminated warnings related to exceeding previously defined maximum values in sensor states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->