### PR TITLE
Use dedicated httpx Client

### DIFF
--- a/custom_components/polestar_api/config_flow.py
+++ b/custom_components/polestar_api/config_flow.py
@@ -85,14 +85,18 @@ class FlowHandler(config_entries.ConfigFlow):
             password=password,
             client_session=get_async_client(self.hass),
         )
-        await api_client.async_init()
 
-        if found_vins := api_client.get_available_vins():
-            _LOGGER.debug("Found %d VINs for %s", len(found_vins), username)
-        else:
-            _LOGGER.warning("No VINs found for %s", username)
-            raise NoCarsFoundException
+        try:
+            await api_client.async_init()
 
-        if vin and vin not in found_vins:
-            _LOGGER.warning("VIN %s not found for %s", vin, username)
-            raise VinNotFoundException
+            if found_vins := api_client.get_available_vins():
+                _LOGGER.debug("Found %d VINs for %s", len(found_vins), username)
+            else:
+                _LOGGER.warning("No VINs found for %s", username)
+                raise NoCarsFoundException
+
+            if vin and vin not in found_vins:
+                _LOGGER.warning("VIN %s not found for %s", vin, username)
+                raise VinNotFoundException
+        finally:
+            await api_client.async_logout()

--- a/custom_components/polestar_api/polestar.py
+++ b/custom_components/polestar_api/polestar.py
@@ -8,7 +8,7 @@ import homeassistant.util.dt as dt_util
 import httpx
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
-from homeassistant.helpers.httpx_client import get_async_client
+from homeassistant.helpers.httpx_client import create_async_httpx_client
 from homeassistant.util import Throttle
 
 from .const import DEFAULT_SCAN_INTERVAL, DOMAIN as POLESTAR_API_DOMAIN
@@ -228,7 +228,7 @@ class PolestarCoordinator:
         self.polestar_api = PolestarApi(
             username=username,
             password=password,
-            client_session=get_async_client(hass),
+            client_session=create_async_httpx_client(hass),
             vins=[vin] if vin else None,
             unique_id=self.unique_id,
         )

--- a/custom_components/polestar_api/pypolestar/const.py
+++ b/custom_components/polestar_api/pypolestar/const.py
@@ -14,5 +14,6 @@ OIDC_PROVIDER_BASE_URL = "https://polestarid.eu.polestar.com"
 OIDC_CLIENT_ID = "l3oopkc_10"
 OIDC_REDIRECT_URI = "https://www.polestar.com/sign-in-callback"
 OIDC_SCOPE = "openid profile email customer:attributes"
+OIDC_COOKIES = ["PF", "PF.PERSISTENT"]
 
 API_MYSTAR_V2_URL = "https://pc-api.polestar.com/eu-north-1/mystar-v2/"

--- a/custom_components/polestar_api/pypolestar/polestar.py
+++ b/custom_components/polestar_api/pypolestar/polestar.py
@@ -90,6 +90,9 @@ class PolestarApi:
         ):
             self.logger.warning("Could not found configured VINs %s", missing_vins)
 
+    async def async_logout(self) -> None:
+        await self.auth.async_logout()
+
     def get_available_vins(self) -> list[str]:
         """Get list of all available VINs"""
         return list(self.available_vins)


### PR DESCRIPTION
- Use a dedicated `httpx.Client` for each API
- Use shared `httpx.Client` when testing credentials, but remove all cookies after testing

Updates #272 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an asynchronous logout functionality for users.
	- Added a new constant for OIDC cookies to enhance API configuration.

- **Bug Fixes**
	- Improved error handling during credential validation and API client updates.

- **Documentation**
	- Updated documentation to reflect changes in authentication attributes and methods.

- **Refactor**
	- Streamlined the HTTP client creation process and restructured error handling in the Polestar API integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->