### PR TITLE
Disable software version sensors by default

### DIFF
--- a/custom_components/polestar_api/sensor.py
+++ b/custom_components/polestar_api/sensor.py
@@ -168,6 +168,7 @@ POLESTAR_SENSOR_TYPES: Final[tuple[PolestarSensorDescription, ...]] = (
         name="Software Version",
         icon="mdi:information-outline",
         native_unit_of_measurement=None,
+        entity_registry_enabled_default=False,
     ),
     PolestarSensorDescription(
         key="software_version_release",
@@ -176,6 +177,7 @@ POLESTAR_SENSOR_TYPES: Final[tuple[PolestarSensorDescription, ...]] = (
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.TIMESTAMP,
         native_unit_of_measurement=None,
+        entity_registry_enabled_default=False,
     ),
     PolestarSensorDescription(
         key="registration_number",


### PR DESCRIPTION
The software version and released sensors seems to report nothing useful, disable them by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new attribute to several sensor descriptions to control their automatic registration in the entity registry.
	- Sensors affected include: `software_version`, `software_version_release`, `internal_vehicle_id`, `api_status_code_data`, `api_status_code_auth`, and `api_token_expires_at`. 

- **Bug Fixes**
	- No existing functionality was disrupted; the sensor system remains stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->