### PR TITLE
Update Readme with additional steps for new users

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ This is the account that you also use in the polestar APP on your mobile phone t
 ## Add in HA Integration
 
 Add custom repository in HACS: https://github.com/pypolestar/polestar_api
-Search for integration 'polestar_api'
-Download the integration
-Go to integrations in HA
+Search for integration 'polestar_api' in HACS
+Download the integration in HACS
+Go to Settings, Integrations in Home Assistant
 Add the Polestar API integration
 
 ### Fill the information

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ This is the account that you also use in the polestar APP on your mobile phone t
 
 ## Add in HA Integration
 
-Add custom repository in HACS: https://github.com/pypolestar/polestar_api
-Search for integration 'polestar_api' in HACS
-Download the integration in HACS
-Go to Settings, Integrations in Home Assistant
-Add the Polestar API integration
+* Add custom repository in HACS: https://github.com/pypolestar/polestar_api
+* Search for integration 'polestar_api' in HACS
+* Download the integration in HACS
+* Go to Settings, Integrations in Home Assistant
+* Add the Polestar API integration
 
 ### Fill the information
 

--- a/README.md
+++ b/README.md
@@ -10,14 +10,6 @@ This is the account that you also use in the polestar APP on your mobile phone t
  
  * HACS (Home Assistant Community Store) must be installed. If you haven't installed HACS yet, follow the [official HACS installation guide](https://hacs.xyz/docs/use/#getting-started-with-hacs).
 
- ## Add in HA Integration
-
- * Add custom repository in HACS: [https://github.com/pypolestar/polestar_api](https://github.com/pypolestar/polestar_api)
- * Search for integration 'polestar_api' in HACS
- * Download the integration in HACS
- * Go to Settings, Integrations in Home Assistant
- * Add the Polestar API integration
-
 ## Add in HA Integration
 
 * Add custom repository in HACS: https://github.com/pypolestar/polestar_api

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ This is the account that you also use in the polestar APP on your mobile phone t
 
 Add custom repository in HACS: https://github.com/pypolestar/polestar_api
 Search for integration 'polestar_api'
+Download the integration
+Go to integrations in HA
+Add the Polestar API integration
 
 ### Fill the information
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@ This application is not an official app affiliated with Polestar.
 
 This is the account that you also use in the polestar APP on your mobile phone try here to login if it works or not: https://polestarid.eu.polestar.com/PolestarLogin/login
 
+ ## Prerequisites
+ 
+ * HACS (Home Assistant Community Store) must be installed. If you haven't installed HACS yet, follow the [official HACS installation guide](https://hacs.xyz/docs/use/#getting-started-with-hacs).
+
+ ## Add in HA Integration
+
+ * Add custom repository in HACS: [https://github.com/pypolestar/polestar_api](https://github.com/pypolestar/polestar_api)
+ * Search for integration 'polestar_api' in HACS
+ * Download the integration in HACS
+ * Go to Settings, Integrations in Home Assistant
+ * Add the Polestar API integration
 
 ## Add in HA Integration
 


### PR DESCRIPTION
Discussion https://github.com/pypolestar/polestar_api/discussions/281 indicates that the instructions are a little light on for new users (particularly new users to HACS).

This PR adds several steps to the readme to indicate the steps needed to set up the integration for the first time, useful for a user who is unfamiliar with HACS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Enhanced README with a new "Prerequisites" section for integrating Polestar API with Home Assistant, including HACS installation guidance.
  - Reformatted instructions into a clearer bulleted list for adding the integration in Home Assistant, detailing steps for downloading and navigating settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->