### PR TITLE
Enable long-term statistics for odometers

### DIFF
--- a/custom_components/polestar_api/sensor.py
+++ b/custom_components/polestar_api/sensor.py
@@ -67,7 +67,7 @@ POLESTAR_SENSOR_TYPES: Final[tuple[PolestarSensorDescription, ...]] = (
         native_unit_of_measurement=UnitOfLength.METERS,
         suggested_unit_of_measurement=UnitOfLength.KILOMETERS,
         suggested_display_precision=0,
-        state_class=SensorStateClass.MEASUREMENT,
+        state_class=SensorStateClass.TOTAL_INCREASING,
         device_class=SensorDeviceClass.DISTANCE,
     ),
     PolestarSensorDescription(
@@ -84,7 +84,7 @@ POLESTAR_SENSOR_TYPES: Final[tuple[PolestarSensorDescription, ...]] = (
         icon="mdi:map-marker-distance",
         native_unit_of_measurement=UnitOfLength.KILOMETERS,
         suggested_display_precision=1,
-        state_class=SensorStateClass.MEASUREMENT,
+        state_class=SensorStateClass.TOTAL_INCREASING,
         device_class=SensorDeviceClass.DISTANCE,
     ),
     PolestarSensorDescription(
@@ -93,7 +93,7 @@ POLESTAR_SENSOR_TYPES: Final[tuple[PolestarSensorDescription, ...]] = (
         icon="mdi:map-marker-distance",
         native_unit_of_measurement=UnitOfLength.KILOMETERS,
         suggested_display_precision=1,
-        state_class=SensorStateClass.MEASUREMENT,
+        state_class=SensorStateClass.TOTAL_INCREASING,
         device_class=SensorDeviceClass.DISTANCE,
     ),
     PolestarSensorDescription(

--- a/custom_components/polestar_api/sensor.py
+++ b/custom_components/polestar_api/sensor.py
@@ -67,7 +67,7 @@ POLESTAR_SENSOR_TYPES: Final[tuple[PolestarSensorDescription, ...]] = (
         native_unit_of_measurement=UnitOfLength.METERS,
         suggested_unit_of_measurement=UnitOfLength.KILOMETERS,
         suggested_display_precision=0,
-        state_class=SensorStateClass.TOTAL_INCREASING,
+        state_class=SensorStateClass.TOTAL,
         device_class=SensorDeviceClass.DISTANCE,
     ),
     PolestarSensorDescription(


### PR DESCRIPTION
Use `SensorStateClass.TOTAL_INCREASING` for odometer and trip_meters as they never decrease. The two trip meters can decrease in case of a new cycle.

See also https://developers.home-assistant.io/docs/core/entity/sensor/#long-term-statistics

Closes #286 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Updated sensor state classification for odometer and trip meter sensors to correctly represent cumulative values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->