### PR TITLE
Use car telematics and add health sensors

### DIFF
--- a/custom_components/polestar_api/coordinator.py
+++ b/custom_components/polestar_api/coordinator.py
@@ -134,7 +134,7 @@ class PolestarCoordinator(DataUpdateCoordinator):
         ):
             return {
                 "days_to_service": data.days_to_service,
-                "distance_to_service_km": data.distance_to_service_km,
+                "distance_to_service": data.distance_to_service_km,
                 "brake_fluid_level_warning": data.brake_fluid_level_warning,
                 "engine_coolant_level_warning": data.engine_coolant_level_warning,
                 "oil_level_warning": data.oil_level_warning,

--- a/custom_components/polestar_api/coordinator.py
+++ b/custom_components/polestar_api/coordinator.py
@@ -139,6 +139,7 @@ class PolestarCoordinator(DataUpdateCoordinator):
                 "engine_coolant_level_warning": data.engine_coolant_level_warning,
                 "oil_level_warning": data.oil_level_warning,
                 "service_warning": data.service_warning,
+                "last_updated_health_data": data.event_updated_timestamp,
             }
         else:
             # log as debug for now as data is missing for some models

--- a/custom_components/polestar_api/coordinator.py
+++ b/custom_components/polestar_api/coordinator.py
@@ -154,8 +154,8 @@ class PolestarCoordinator(DataUpdateCoordinator):
             await self.polestar_api.update_latest_data(
                 vin=self.vin,
                 update_telematics=True,
-                update_battery=True,
-                update_odometer=True,
+                update_battery=False,
+                update_odometer=False,
             )
             res.update(self.get_car_odometer())
             res.update(self.get_car_battery())

--- a/custom_components/polestar_api/manifest.json
+++ b/custom_components/polestar_api/manifest.json
@@ -8,7 +8,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/pypolestar/polestar_api/issues",
   "requirements": [
-    "pypolestar==1.3.0",
+    "pypolestar==1.4.0",
     "gql[httpx]>=3.5.0",
     "homeassistant>=2024.6.0"
   ],

--- a/custom_components/polestar_api/sensor.py
+++ b/custom_components/polestar_api/sensor.py
@@ -186,6 +186,13 @@ ENTITY_DESCRIPTIONS: Final[tuple[PolestarSensorDescription, ...]] = (
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     PolestarSensorDescription(
+        key="last_updated_health_data",
+        icon="mdi:clock",
+        native_unit_of_measurement=None,
+        device_class=SensorDeviceClass.TIMESTAMP,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    PolestarSensorDescription(
         key="estimated_full_charge_range",
         icon="mdi:map-marker-distance",
         native_unit_of_measurement=UnitOfLength.KILOMETERS,

--- a/custom_components/polestar_api/sensor.py
+++ b/custom_components/polestar_api/sensor.py
@@ -241,7 +241,7 @@ ENTITY_DESCRIPTIONS: Final[tuple[PolestarSensorDescription, ...]] = (
         suggested_display_precision=0,
     ),
     PolestarSensorDescription(
-        key="distance_to_service_km",
+        key="distance_to_service",
         icon="mdi:map-marker-distance",
         native_unit_of_measurement=UnitOfLength.KILOMETERS,
         suggested_display_precision=0,

--- a/custom_components/polestar_api/sensor.py
+++ b/custom_components/polestar_api/sensor.py
@@ -236,7 +236,7 @@ ENTITY_DESCRIPTIONS: Final[tuple[PolestarSensorDescription, ...]] = (
     ),
     PolestarSensorDescription(
         key="days_to_service",
-        icon="mdi:timer-outline",
+        icon="mdi:calendar",
         native_unit_of_measurement=UnitOfTime.DAYS,
         suggested_display_precision=0,
     ),

--- a/custom_components/polestar_api/sensor.py
+++ b/custom_components/polestar_api/sensor.py
@@ -227,6 +227,40 @@ ENTITY_DESCRIPTIONS: Final[tuple[PolestarSensorDescription, ...]] = (
         state_class=SensorStateClass.TOTAL,
         device_class=SensorDeviceClass.ENERGY,
     ),
+    PolestarSensorDescription(
+        key="days_to_service",
+        icon="mdi:timer-outline",
+        native_unit_of_measurement=UnitOfTime.DAYS,
+        suggested_display_precision=0,
+    ),
+    PolestarSensorDescription(
+        key="distance_to_service_km",
+        icon="mdi:map-marker-distance",
+        native_unit_of_measurement=UnitOfLength.KILOMETERS,
+        suggested_display_precision=0,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.DISTANCE,
+    ),
+    PolestarSensorDescription(
+        key="brake_fluid_level_warning",
+        icon="mdi:alert",
+        native_unit_of_measurement=None,
+    ),
+    PolestarSensorDescription(
+        key="engine_coolant_level_warning",
+        icon="mdi:alert",
+        native_unit_of_measurement=None,
+    ),
+    PolestarSensorDescription(
+        key="oil_level_warning",
+        icon="mdi:alert",
+        native_unit_of_measurement=None,
+    ),
+    PolestarSensorDescription(
+        key="service_warning",
+        icon="mdi:alert",
+        native_unit_of_measurement=None,
+    ),
 )
 
 

--- a/custom_components/polestar_api/strings.json
+++ b/custom_components/polestar_api/strings.json
@@ -105,6 +105,9 @@
       "polestar_last_updated_battery_data": {
         "name": "Last Updated Battery Data"
       },
+      "polestar_last_updated_health_data": {
+        "name": "Last updated health data"
+      },
       "polestar_last_updated_odometer_data": {
         "name": "Last Updated Odometer Data"
       },

--- a/custom_components/polestar_api/strings.json
+++ b/custom_components/polestar_api/strings.json
@@ -78,7 +78,7 @@
       "polestar_days_to_service": {
         "name": "Days to service"
       },
-      "polestar_distance_to_service_km": {
+      "polestar_distance_to_service": {
         "name": "Distance to Service"
       },
       "polestar_engine_coolant_level_warning": {

--- a/custom_components/polestar_api/strings.json
+++ b/custom_components/polestar_api/strings.json
@@ -51,6 +51,9 @@
       "polestar_battery_charge_level": {
         "name": "Battery Charge Level"
       },
+      "polestar_brake_fluid_level_warning": {
+        "name": "Brake fluid level warning"
+      },
       "polestar_charger_connection_status": {
         "name": "Charger Connection Status"
       },
@@ -72,6 +75,12 @@
       "polestar_current_trip_meter_manual": {
         "name": "Trip Meter Manual"
       },
+      "polestar_days_to_service": {
+        "name": "Days to service"
+      },
+      "polestar_engine_coolant_level_warning": {
+        "name": "Engine coolant level warning"
+      },
       "polestar_estimated_charging_time_to_full": {
         "name": "Charging Time"
       },
@@ -90,6 +99,9 @@
       "polestar_internal_vehicle_id": {
         "name": "Internal Vehicle ID"
       },
+      "polestar_istance_to_service_km": {
+        "name": "Distance to service"
+      },
       "polestar_last_updated_battery_data": {
         "name": "Last Updated Battery Data"
       },
@@ -99,8 +111,14 @@
       "polestar_model_name": {
         "name": "Model Name"
       },
+      "polestar_oil_level_warning": {
+        "name": "Oil level warning"
+      },
       "polestar_registration_number": {
         "name": "Registration Number"
+      },
+      "polestar_service_warning": {
+        "name": "Service warning"
       },
       "polestar_software_version": {
         "name": "Software Version"

--- a/custom_components/polestar_api/strings.json
+++ b/custom_components/polestar_api/strings.json
@@ -78,6 +78,9 @@
       "polestar_days_to_service": {
         "name": "Days to service"
       },
+      "polestar_distance_to_service_km": {
+        "name": "Distance to Service"
+      },
       "polestar_engine_coolant_level_warning": {
         "name": "Engine Coolant Level Warning"
       },
@@ -98,9 +101,6 @@
       },
       "polestar_internal_vehicle_id": {
         "name": "Internal Vehicle ID"
-      },
-      "polestar_istance_to_service_km": {
-        "name": "Distance to Service"
       },
       "polestar_last_updated_battery_data": {
         "name": "Last Updated Battery Data"

--- a/custom_components/polestar_api/strings.json
+++ b/custom_components/polestar_api/strings.json
@@ -40,7 +40,7 @@
         "name": "API Token Expires At"
       },
       "polestar_average_energy_consumption": {
-        "name": "Avg. Energy Consumption"
+        "name": "Average Energy Consumption"
       },
       "polestar_average_speed": {
         "name": "Average Speed"
@@ -52,7 +52,7 @@
         "name": "Battery Charge Level"
       },
       "polestar_brake_fluid_level_warning": {
-        "name": "Brake fluid level warning"
+        "name": "Brake Fluid Level Warning"
       },
       "polestar_charger_connection_status": {
         "name": "Charger Connection Status"
@@ -79,7 +79,7 @@
         "name": "Days to service"
       },
       "polestar_engine_coolant_level_warning": {
-        "name": "Engine coolant level warning"
+        "name": "Engine Coolant Level Warning"
       },
       "polestar_estimated_charging_time_to_full": {
         "name": "Charging Time"
@@ -100,13 +100,13 @@
         "name": "Internal Vehicle ID"
       },
       "polestar_istance_to_service_km": {
-        "name": "Distance to service"
+        "name": "Distance to Service"
       },
       "polestar_last_updated_battery_data": {
         "name": "Last Updated Battery Data"
       },
       "polestar_last_updated_health_data": {
-        "name": "Last updated health data"
+        "name": "Last Updated Health Data"
       },
       "polestar_last_updated_odometer_data": {
         "name": "Last Updated Odometer Data"
@@ -115,13 +115,13 @@
         "name": "Model Name"
       },
       "polestar_oil_level_warning": {
-        "name": "Oil level warning"
+        "name": "Oil Level Warning"
       },
       "polestar_registration_number": {
         "name": "Registration Number"
       },
       "polestar_service_warning": {
-        "name": "Service warning"
+        "name": "Service Warning"
       },
       "polestar_software_version": {
         "name": "Software Version"

--- a/custom_components/polestar_api/translations/en.json
+++ b/custom_components/polestar_api/translations/en.json
@@ -78,7 +78,7 @@
       "polestar_days_to_service": {
         "name": "Days to service"
       },
-      "polestar_distance_to_service_km": {
+      "polestar_distance_to_service": {
         "name": "Distance to Service"
       },
       "polestar_engine_coolant_level_warning": {

--- a/custom_components/polestar_api/translations/en.json
+++ b/custom_components/polestar_api/translations/en.json
@@ -1,11 +1,5 @@
 {
   "config": {
-    "abort": {
-      "already_configured": "Polestar API is already configured",
-      "api_failed": "Unexpected error creating API.",
-      "api_timeout": "Timeout connecting to the API.",
-      "no_token": "No token found in response. Please check your credentials."
-    },
     "error": {
       "api": "Error connecting to Polestar API.",
       "auth_failed": "Invalid username/password.",
@@ -57,6 +51,9 @@
       "polestar_battery_charge_level": {
         "name": "Battery Charge Level"
       },
+      "polestar_brake_fluid_level_warning": {
+        "name": "Brake Fluid Level Warning"
+      },
       "polestar_charger_connection_status": {
         "name": "Charger Connection Status"
       },
@@ -78,6 +75,12 @@
       "polestar_current_trip_meter_manual": {
         "name": "Trip Meter Manual"
       },
+      "polestar_days_to_service": {
+        "name": "Days to service"
+      },
+      "polestar_engine_coolant_level_warning": {
+        "name": "Engine Coolant Level Warning"
+      },
       "polestar_estimated_charging_time_to_full": {
         "name": "Charging Time"
       },
@@ -93,8 +96,17 @@
       "polestar_estimated_range": {
         "name": "Range"
       },
+      "polestar_internal_vehicle_id": {
+        "name": "Internal Vehicle ID"
+      },
+      "polestar_istance_to_service_km": {
+        "name": "Distance to Service"
+      },
       "polestar_last_updated_battery_data": {
         "name": "Last Updated Battery Data"
+      },
+      "polestar_last_updated_health_data": {
+        "name": "Last Updated Health Data"
       },
       "polestar_last_updated_odometer_data": {
         "name": "Last Updated Odometer Data"
@@ -102,11 +114,20 @@
       "polestar_model_name": {
         "name": "Model Name"
       },
+      "polestar_oil_level_warning": {
+        "name": "Oil Level Warning"
+      },
       "polestar_registration_number": {
         "name": "Registration Number"
       },
+      "polestar_service_warning": {
+        "name": "Service Warning"
+      },
       "polestar_software_version": {
         "name": "Software Version"
+      },
+      "polestar_software_version_release": {
+        "name": "Software Version Release"
       },
       "polestar_torque": {
         "name": "Torque"

--- a/custom_components/polestar_api/translations/en.json
+++ b/custom_components/polestar_api/translations/en.json
@@ -78,6 +78,9 @@
       "polestar_days_to_service": {
         "name": "Days to service"
       },
+      "polestar_distance_to_service_km": {
+        "name": "Distance to Service"
+      },
       "polestar_engine_coolant_level_warning": {
         "name": "Engine Coolant Level Warning"
       },
@@ -98,9 +101,6 @@
       },
       "polestar_internal_vehicle_id": {
         "name": "Internal Vehicle ID"
-      },
-      "polestar_istance_to_service_km": {
-        "name": "Distance to Service"
       },
       "polestar_last_updated_battery_data": {
         "name": "Last Updated Battery Data"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ pip>=21.3.1
 ruff==0.8.6
 gql[httpx]>=3.5.0
 pytest>=8.3.3
-pypolestar==1.3.0
+pypolestar==1.4.0


### PR DESCRIPTION
- Fetch data from Polestar API using car telematics call
- Add health sensors (only for Polestar 2?)

closes #225 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added new vehicle health sensors including brake fluid, coolant, and oil level warnings.
	- Introduced sensors for service-related information like days to service and distance to service.
	- Added a new method to retrieve car health data.

- **Improvements**
	- Streamlined data retrieval by consolidating multiple API calls into a single telematics call.
	- Updated pypolestar library to version 1.4.0.

- **Sensor Updates**
	- Added sensors for last updated health data, vehicle maintenance, and status tracking.
	- Enhanced descriptive capabilities for sensors in the interface.
	- Updated sensor names for clarity in the user interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->