### PR TITLE
Fix device class for sensor estimated_fully_charged_time

### DIFF
--- a/custom_components/polestar_api/manifest.json
+++ b/custom_components/polestar_api/manifest.json
@@ -12,5 +12,5 @@
     "gql[httpx]>=3.5.0",
     "homeassistant>=2024.6.0"
   ],
-  "version": "1.14.0"
+  "version": "1.14.1"
 }

--- a/custom_components/polestar_api/sensor.py
+++ b/custom_components/polestar_api/sensor.py
@@ -6,7 +6,6 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Final
 
-import homeassistant.util.dt as dt_util
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -259,13 +258,9 @@ BATTERY_ENTITY_DESCRIPTIONS: Final[tuple[PolestarSensorDescription, ...]] = (
         key="estimated_fully_charged_time",
         icon="mdi:battery-clock",
         native_unit_of_measurement=None,
-        state_class=SensorStateClass.MEASUREMENT,
-        device_class=SensorDeviceClass.DURATION,
+        device_class=SensorDeviceClass.TIMESTAMP,
         data_source=PolestarEntityDataSource.BATTERY,
         data_state_attribute="estimated_fully_charged",
-        data_state_fn=lambda value: dt_util.as_local(value).strftime(
-            "%Y-%m-%d %H:%M:%S"
-        ),
     ),
     PolestarSensorDescription(
         key="last_updated_battery_data",


### PR DESCRIPTION
`estimated_fully_charged_time` should be a timestamp (`datetime`), not a string. Fix and bump version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the API component version to 1.14.1.
  
- **New Features**
  - Enhanced the display of the estimated fully charged time sensor by adjusting its data classification, now presenting the information as a timestamp for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->