### PR TITLE
Remove fallback for old units of measurement

### DIFF
--- a/custom_components/polestar_api/manifest.json
+++ b/custom_components/polestar_api/manifest.json
@@ -10,7 +10,7 @@
   "requirements": [
     "pypolestar==1.7.0",
     "gql[httpx]>=3.5.0",
-    "homeassistant>=2024.6.0"
+    "homeassistant>=2025.3.0"
   ],
-  "version": "1.15.0"
+  "version": "1.16.0"
 }

--- a/custom_components/polestar_api/sensor.py
+++ b/custom_components/polestar_api/sensor.py
@@ -17,21 +17,12 @@ from homeassistant.const import (
     EntityCategory,
     UnitOfElectricCurrent,
     UnitOfEnergy,
+    UnitOfEnergyDistance,
     UnitOfLength,
     UnitOfPower,
     UnitOfSpeed,
     UnitOfTime,
 )
-
-# TODO: Remove this hack once 2025.4.0 is released (one month after 2025.3.0)
-try:
-    from homeassistant.const import UnitOfEnergyDistance
-
-    UNIT_OF_ENERGY_DISTANCE = UnitOfEnergyDistance.KILO_WATT_HOUR_PER_100_KM
-    DEVICE_CLASS_ENERGY_DISTANCE = SensorDeviceClass.ENERGY_DISTANCE
-except ImportError:
-    UNIT_OF_ENERGY_DISTANCE = "kWh/100km"
-    DEVICE_CLASS_ENERGY_DISTANCE = None
 
 from .entity import (
     PolestarEntity,
@@ -248,10 +239,10 @@ BATTERY_ENTITY_DESCRIPTIONS: Final[tuple[PolestarSensorDescription, ...]] = (
     PolestarSensorDescription(
         key="average_energy_consumption",
         icon="mdi:lightning-bolt-circle",
-        native_unit_of_measurement=UNIT_OF_ENERGY_DISTANCE,
+        native_unit_of_measurement=UnitOfEnergyDistance.KILO_WATT_HOUR_PER_100_KM,
         suggested_display_precision=1,
         state_class=SensorStateClass.MEASUREMENT,
-        device_class=DEVICE_CLASS_ENERGY_DISTANCE,
+        device_class=SensorDeviceClass.ENERGY_DISTANCE,
         data_source=PolestarEntityDataSource.BATTERY,
         data_state_attribute="average_energy_consumption_kwh_per_100km",
     ),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 colorlog==6.8.2
-homeassistant>=2025.2.5
+homeassistant>=2025.3.0
 pip>=21.3.1
 ruff==0.8.6
 gql[httpx]>=3.5.0


### PR DESCRIPTION
Remove hack to support old versions without energy of distance units. The integration now requires 2025.3 or later.