### PR TITLE
Set correct HASS version

### DIFF
--- a/custom_components/polestar_api/manifest.json
+++ b/custom_components/polestar_api/manifest.json
@@ -12,7 +12,7 @@
   "issue_tracker": "https://github.com/pypolestar/polestar_api/issues",
   "requirements": [
     "pypolestar==1.12.2",
-    "homeassistant>=2025.4.0"
+    "homeassistant>=2026.4.0"
   ],
   "version": "1.23.1"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 colorlog==6.8.2
-homeassistant>=2025.4.0
+homeassistant>=2026.4.0
 pip>=21.3.1
 ruff==0.11.0
 gql[httpx]>=3.5.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Home Assistant core version requirement from 2025.4.0 to 2026.4.0. Users will need to upgrade their Home Assistant installation to use this integration going forward.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pypolestar/polestar_api/pull/418)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->