### PR TITLE
Prepare for release 1.24.1

### DIFF
--- a/custom_components/polestar_api/manifest.json
+++ b/custom_components/polestar_api/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/pypolestar/polestar_api",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/pypolestar/polestar_api/issues",
-  "requirements": ["pypolestar==1.12.5", "homeassistant>=2026.4.0"],
-  "version": "1.24.0"
+  "requirements": ["pypolestar==1.12.6", "homeassistant>=2026.4.0"],
+  "version": "1.24.1"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ pip>=21.3.1
 ruff==0.11.0
 gql[httpx]>=3.5.0
 pytest>=8.3.3
-pypolestar==1.12.5
+pypolestar==1.12.6


### PR DESCRIPTION
Bump `pypolestar` requirement to only compute `estimated_fully_charged` while charging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Polestar integration to improve compatibility and reliability.
  * Incremented the integration version to 1.24.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->