### PR TITLE
Fix homeassistant dependency

### DIFF
--- a/custom_components/polestar_api/manifest.json
+++ b/custom_components/polestar_api/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/pypolestar/polestar_api",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/pypolestar/polestar_api/issues",
-  "requirements": ["pypolestar==1.12.6", "homeassistant>=2026.4.0"],
-  "version": "1.24.1"
+  "requirements": ["pypolestar==1.12.6"],
+  "version": "1.24.2"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
-    "name": "Polestar API",
-    "homeassistant": "2023.10.0"
+  "name": "Polestar API",
+  "homeassistant": "2026.4.0"
 }


### PR DESCRIPTION
closes #438 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the integration to version 1.24.2.

* **Compatibility**
  * Updated the declared Home Assistant compatibility requirement to version 2026.4.0.
  * Refined dependency requirements to use the pinned Polestar API library version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->