### PR TITLE
Only try to update gRPC if supported

### DIFF
--- a/custom_components/polestar_api/coordinator.py
+++ b/custom_components/polestar_api/coordinator.py
@@ -125,6 +125,7 @@ class PolestarCoordinator(DataUpdateCoordinator):
                 self.grpc_battery_data = self.polestar_api.get_grpc_battery(self.vin)
             else:
                 self.grpc_battery_data = None
+                _LOGGER.debug("No gRPC battery data for VIN %s", self.vin)
 
             if self.polestar_api.is_grpc_target_soc_supported(self.vin):
                 self.grpc_target_soc_data = self.polestar_api.get_grpc_target_soc(
@@ -132,11 +133,6 @@ class PolestarCoordinator(DataUpdateCoordinator):
                 )
             else:
                 self.grpc_target_soc_data = None
-
-            if not self.grpc_battery_data:
-                _LOGGER.debug("No gRPC battery data for VIN %s", self.vin)
-
-            if not self.grpc_target_soc_data:
                 _LOGGER.debug("No gRPC target SOC data for VIN %s", self.vin)
 
         except PolestarAuthFailedException as exc:

--- a/custom_components/polestar_api/coordinator.py
+++ b/custom_components/polestar_api/coordinator.py
@@ -121,8 +121,12 @@ class PolestarCoordinator(DataUpdateCoordinator):
             # gRPC data: charger connection status and charging target level.
             # This is best-effort; pypolestar treats gRPC as non-fatal and these
             # getters return None when the data is unavailable.
-            self.grpc_battery_data = self.polestar_api.get_grpc_battery(self.vin)
-            self.grpc_target_soc_data = self.polestar_api.get_grpc_target_soc(self.vin)
+            if self.polestar_api.is_grpc_battery_supported(self.vin):
+                self.grpc_battery_data = self.polestar_api.get_grpc_battery(self.vin)
+            if self.polestar_api.is_grpc_target_soc_supported(self.vin):
+                self.grpc_target_soc_data = self.polestar_api.get_grpc_target_soc(
+                    self.vin
+                )
 
             if not self.grpc_battery_data:
                 _LOGGER.debug("No gRPC battery data for VIN %s", self.vin)

--- a/custom_components/polestar_api/coordinator.py
+++ b/custom_components/polestar_api/coordinator.py
@@ -123,10 +123,15 @@ class PolestarCoordinator(DataUpdateCoordinator):
             # getters return None when the data is unavailable.
             if self.polestar_api.is_grpc_battery_supported(self.vin):
                 self.grpc_battery_data = self.polestar_api.get_grpc_battery(self.vin)
+            else:
+                self.grpc_battery_data = None
+
             if self.polestar_api.is_grpc_target_soc_supported(self.vin):
                 self.grpc_target_soc_data = self.polestar_api.get_grpc_target_soc(
                     self.vin
                 )
+            else:
+                self.grpc_target_soc_data = None
 
             if not self.grpc_battery_data:
                 _LOGGER.debug("No gRPC battery data for VIN %s", self.vin)

--- a/custom_components/polestar_api/manifest.json
+++ b/custom_components/polestar_api/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/pypolestar/polestar_api",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/pypolestar/polestar_api/issues",
-  "requirements": ["pypolestar==1.12.6"],
-  "version": "1.24.2"
+  "requirements": ["pypolestar==1.12.7"],
+  "version": "1.24.3"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ pip>=21.3.1
 ruff==0.11.0
 gql[httpx]>=3.5.0
 pytest>=8.3.3
-pypolestar==1.12.6
+pypolestar==1.12.7


### PR DESCRIPTION
closes #440 #442 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Battery and target state-of-charge data are now retrieved only when supported by the vehicle.
  - Unsupported data is cleared instead of retaining outdated values, improving accuracy for vehicles without these capabilities.

- **Chores**
  - Updated the Polestar API integration and supporting library to newer patch versions for improved compatibility and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->